### PR TITLE
fix: escape @mentions in GitHub issues to prevent unwanted notifications

### DIFF
--- a/src/github.ts
+++ b/src/github.ts
@@ -214,9 +214,18 @@ function neutralizeGitHubRefs(text: string): string {
   return text.replace(/https:\/\/github\.com\//g, "https://github\u200B.com/");
 }
 
+/**
+ * Inserts a zero-width space (U+200B) after `@` so GitHub doesn't parse
+ * usernames in digest content as real @mentions and spam innocent people.
+ */
+function escapeMentions(text: string): string {
+  return text.replace(/@([a-zA-Z0-9])/g, "@\u200B$1");
+}
+
 export async function createGitHubIssue(title: string, body: string, label: string): Promise<string> {
   const digestRepo = process.env["DIGEST_REPO"] ?? "";
   body = neutralizeGitHubRefs(body);
+  body = escapeMentions(body);
   if (body.length > GITHUB_ISSUE_BODY_LIMIT) {
     body = body.slice(0, GITHUB_ISSUE_BODY_LIMIT - TRUNCATION_NOTICE.length) + TRUNCATION_NOTICE;
   }


### PR DESCRIPTION
## Problem

Digest content frequently contains GitHub usernames (`@someone`) from PR authors, issue reporters, and social media posts. When posted verbatim to a GitHub issue, these are parsed as real @mentions — triggering notifications to people who have nothing to do with the digest.

We got user complaints about this.

## Fix

Add an `escapeMentions()` helper that inserts a zero-width space (`U+200B`) between `@` and the username:

```ts
function escapeMentions(text: string): string {
  return text.replace(/@([a-zA-Z0-9])/g, "@\u200B$1");
}
```

The result is visually identical (`@someone` still renders as `@someone`) but GitHub's mention parser doesn't recognize it, so no notifications are sent.

This is the same zero-width-space technique already used by `neutralizeGitHubRefs()` for cross-repo link suppression — placed right alongside it for consistency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)