### PR TITLE
fix: prevent false positives in OpenAI web report from lastmod churn

### DIFF
--- a/src/prompts-data.ts
+++ b/src/prompts-data.ts
@@ -162,19 +162,27 @@ export function buildWebReportPrompt(results: WebFetchResult[], dateStr: string,
         return `## ${siteName}\n\n${noContent}`;
       }
 
-      const unableToExtract = lang === "en" ? "(Unable to extract text content)" : "（无法提取文本内容）";
       const categoryLabel = lang === "en" ? "Category" : "分类";
       const dateLabel = lang === "en" ? "Published/Updated" : "发布/更新";
       const unknownDate = lang === "en" ? "unknown" : "未知";
       const excerptLabel = lang === "en" ? "Excerpt" : "内容节选";
+      const metadataOnlyNote =
+        lang === "en"
+          ? "(metadata-only: title derived from URL slug, may be inaccurate; no article text available)"
+          : "（仅元数据：标题由 URL 路径推断，可能不准确；无法获取正文内容）";
       const itemsText = newItems
-        .map((item) =>
-          [
+        .map((item) => {
+          const lines = [
             `### [${item.title || item.url}](${item.url})`,
             `- ${categoryLabel}: ${item.category} | ${dateLabel}: ${item.lastmod.slice(0, 10) || unknownDate}`,
-            `- ${excerptLabel}: ${item.content || unableToExtract}`,
-          ].join("\n"),
-        )
+          ];
+          if (item.content) {
+            lines.push(`- ${excerptLabel}: ${item.content}`);
+          } else {
+            lines.push(`- ${metadataOnlyNote}`);
+          }
+          return lines.join("\n");
+        })
         .join("\n\n");
 
       const lp = lang === "en" ? "(" : "（";
@@ -211,6 +219,7 @@ Generate a detailed AI Official Content Tracking Report in English with these se
    - If first full crawl, trace important milestones chronologically
 
 3. **OpenAI Content Highlights** — Same structure, organized by research / release / company / safety categories
+   - ⚠️ Note: OpenAI data is metadata-only (titles derived from URL slugs, no article text). Only list URLs and categories objectively. Do NOT speculate on title meanings or fabricate content summaries. If information is insufficient for analysis, state the data limitation clearly.
 
 4. **Strategic Signal Analysis** — Based on both companies' release cadence and content focus, analyze:
    - Each company's recent technical priorities (model capabilities / safety / productization / ecosystem)
@@ -244,6 +253,7 @@ ${siteSections}
    - 如首次全量，按时间线梳理重要里程碑
 
 3. **OpenAI 内容精选** — 同上，按 research / release / company / safety 等分类整理
+   - ⚠️ 注意：OpenAI 数据为仅元数据模式（标题由 URL 路径推断，无正文）。请仅基于 URL 和分类进行客观列举，不要对标题含义进行推测性解读或编造内容摘要。如果信息不足以分析，直接说明数据受限即可。
 
 4. **战略信号解读** — 基于两家公司的发布节奏和内容重点，分析：
    - 各自近期的技术优先级（模型能力 / 安全 / 产品化 / 生态）

--- a/src/web.ts
+++ b/src/web.ts
@@ -291,11 +291,14 @@ export async function fetchSiteContent(
     return b.lastmod.localeCompare(a.lastmod);
   });
 
-  // New = not seen before, OR lastmod is newer than what we stored
+  // New = not seen before, OR (for non-metadataOnly sites) lastmod is newer.
+  // For metadataOnly sites (e.g. OpenAI), lastmod reflects sitemap generation
+  // time rather than content publication — ignore lastmod changes to avoid
+  // flagging hundreds of unchanged URLs as "new" on every run.
   const newUrls = allDiscovered.filter(({ loc, lastmod }) => {
     const prev = siteState.seenUrls[loc];
     if (!prev) return true;
-    if (lastmod && lastmod > prev) return true;
+    if (!cfg.metadataOnly && lastmod && lastmod > prev) return true;
     return false;
   });
 


### PR DESCRIPTION
First of all, thank you for building agents-radar! It's an incredibly well-architected project — the pipeline design, the bilingual support, and the sitemap-based web tracking are all excellent. I've learned a lot from the codebase. 🙏

## Problem

The OpenAI web report consistently produces unreliable content because of two compounding issues:

### 1. Sitemap `lastmod` reflects generation time, not publication time

OpenAI's sitemap regenerates `lastmod` timestamps on every crawl cycle. Since `metadataOnly` is `true` for OpenAI (Cloudflare blocks page fetches), the system can't verify actual content changes. Result: **every run flags 50+ unchanged URLs as "new"**.

### 2. LLM over-interprets URL slugs

With `metadataOnly` mode, titles are derived from URL path segments (e.g., `introducing-gpt-5-2` → "Introducing Gpt 5 2"). The prompt labels missing content as "Unable to extract text content", but the LLM still tries to analyze these slug-derived titles as if they were real headlines, producing speculative and potentially misleading analysis.

Example from actual output:
> 请注意：OpenAI 的抓取列表显示了大量 URL，但主要内容文本提取失败。然而，这些 URL 拼写（如 Introducing Gpt 5 2、Gpt 5 1 Codex Max）本身就构成了极强的战略信号。

## Fix

**`src/web.ts`** — For `metadataOnly` sites, skip lastmod-based change detection. Only truly never-seen URLs are treated as new:

```typescript
// Before: triggers on lastmod changes (false positives for OpenAI)
if (lastmod && lastmod > prev) return true;

// After: only for sites where we can verify content changed
if (!cfg.metadataOnly && lastmod && lastmod > prev) return true;
```

**`src/prompts-data.ts`** — Two improvements:
1. Replace generic "Unable to extract text content" with explicit metadata-only explanation (in both EN/ZH)
2. Add clear instruction to the LLM not to speculate on URL slug meanings or fabricate summaries

## Result

| Metric | Before | After |
|--------|--------|-------|
| "New" OpenAI URLs per run | 50+ (false positives) | 0 (only genuinely new) |
| LLM behavior | Speculates on URL slugs | Reports data limitation clearly |

## Test plan

- [x] TypeScript compiles cleanly
- [x] Verified locally: incremental run detects 0 false-positive new URLs for OpenAI
- [x] Anthropic (non-metadataOnly) continues to use lastmod-based detection as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)