### PR TITLE
Track agenttrace CLI ecosystem updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,7 @@ wrangler deploy
 | OpenCode | [anomalyco/opencode](https://github.com/anomalyco/opencode) |
 | Pi | [badlogic/pi-mono](https://github.com/badlogic/pi-mono) |
 | Qwen Code | [QwenLM/qwen-code](https://github.com/QwenLM/qwen-code) |
+| agenttrace | [luoyuctl/agenttrace](https://github.com/luoyuctl/agenttrace) |
 
 ### Claude Code Skills (GitHub)
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -125,6 +125,7 @@ wrangler deploy
 | Kimi Code CLI | [MoonshotAI/kimi-cli](https://github.com/MoonshotAI/kimi-cli) |
 | OpenCode | [anomalyco/opencode](https://github.com/anomalyco/opencode) |
 | Qwen Code | [QwenLM/qwen-code](https://github.com/QwenLM/qwen-code) |
+| agenttrace | [luoyuctl/agenttrace](https://github.com/luoyuctl/agenttrace) |
 
 ### Claude Code Skills（GitHub）
 

--- a/config.yml
+++ b/config.yml
@@ -32,6 +32,9 @@ cli_repos:
   - id: qwen-code
     repo: QwenLM/qwen-code
     name: Qwen Code
+  - id: agenttrace
+    repo: luoyuctl/agenttrace
+    name: agenttrace
 
 # ── Claude Code Skills ────────────────────────────────────────────────────────
 # Tracked separately without a date filter, sorted by community engagement.


### PR DESCRIPTION
## Summary
- add agenttrace to the tracked AI CLI/tool repositories in config.yml
- document the new tracked source in both English and Chinese READMEs

## Why
agenttrace is a local TUI for AI coding-agent session logs, covering Claude Code, Codex CLI, Gemini CLI, Aider, Cursor exports, OpenClaw, and related CLI ecosystems. Tracking its releases and PRs fits the AI CLI/tools digest scope.

## Validation
- git diff --check
- pnpm install --frozen-lockfile
- pnpm test
- pnpm typecheck
- commit hook: pnpm lint, pnpm format:check, pnpm typecheck