### PR TITLE
feat: add Reddit (r/LocalLLaMA) data source and ranking pipeline

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -92,3 +92,11 @@ openclaw_peers:
   - id: zeroclaw
     repo: zeroclaw-labs/zeroclaw
     name: ZeroClaw
+
+# ── Reddit Ingestion ──────────────────────────────────────────────────────────
+# Tracked subreddits. enabled determines if the ingestion runs.
+reddit:
+  enabled: true
+  subreddits:
+    - LocalLLaMA
+

--- a/src/__tests__/prompt-builders.test.ts
+++ b/src/__tests__/prompt-builders.test.ts
@@ -12,12 +12,14 @@ import {
   buildWeeklyPrompt,
   buildMonthlyPrompt,
   buildHnPrompt,
+  buildRedditPrompt,
 } from "../prompts-data.ts";
 import type { RepoConfig, GitHubItem, GitHubRelease } from "../github.ts";
 import type { RepoDigest } from "../prompts.ts";
 import type { TrendingData } from "../trending.ts";
 import type { HnData } from "../hn.ts";
 import type { WebFetchResult } from "../web.ts";
+import type { RedditData } from "../reddit.ts";
 
 // ---------------------------------------------------------------------------
 // Fixtures
@@ -355,3 +357,59 @@ describe("buildHnPrompt", () => {
     expect(result).toContain("Hacker News");
   });
 });
+
+// ---------------------------------------------------------------------------
+// buildRedditPrompt
+// ---------------------------------------------------------------------------
+
+describe("buildRedditPrompt", () => {
+  it("includes reddit posts with metadata", () => {
+    const data: RedditData = {
+      posts: [
+        {
+          id: "abc",
+          title: "Local LLM releasing",
+          url: "https://example.com/llm",
+          redditUrl: "https://reddit.com/r/LocalLLaMA/comments/abc",
+          score: 150,
+          comments: 45,
+          author: "alice",
+          subreddit: "LocalLLaMA",
+          createdAt: "2026-03-09T10:00:00Z",
+          postText: "This is a great new local model.",
+        },
+      ],
+      fetchSuccess: true,
+    };
+    const result = buildRedditPrompt(data, "2026-03-09");
+    expect(result).toContain("Local LLM releasing");
+    expect(result).toContain("分数: 150");
+    expect(result).toContain("评论: 45");
+    expect(result).toContain("作者: alice");
+    expect(result).toContain("r/LocalLLaMA");
+  });
+
+  it("generates English variant", () => {
+    const data: RedditData = {
+      posts: [
+        {
+          id: "xyz",
+          title: "New hardware tweaks",
+          url: "https://reddit.com/r/LocalLLaMA/comments/xyz",
+          redditUrl: "https://reddit.com/r/LocalLLaMA/comments/xyz",
+          score: 50,
+          comments: 12,
+          author: "bob",
+          subreddit: "LocalLLaMA",
+          createdAt: "2026-03-09T10:00:00Z",
+        },
+      ],
+      fetchSuccess: true,
+    };
+    const result = buildRedditPrompt(data, "2026-03-09", "en");
+    expect(result).toContain("Score: 50");
+    expect(result).toContain("Comments: 12");
+    expect(result).toContain("Reddit");
+  });
+});
+

--- a/src/__tests__/reddit.test.ts
+++ b/src/__tests__/reddit.test.ts
@@ -1,0 +1,149 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { fetchRedditData } from "../reddit.ts";
+
+describe("fetchRedditData", () => {
+  const originalFetch = global.fetch;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    // Enforce a stable current time: 2026-03-09T12:00:00Z
+    vi.setSystemTime(new Date("2026-03-09T12:00:00Z"));
+  });
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+    vi.useRealTimers();
+  });
+
+  it("successfully fetches, filters, and ranks reddit posts", async () => {
+    const mockResponse = {
+      data: {
+        children: [
+          {
+            data: {
+              id: "post1",
+              title: "Normal Active Post",
+              author: "user1",
+              score: 100,
+              num_comments: 50,
+              subreddit: "LocalLLaMA",
+              permalink: "/r/LocalLLaMA/comments/post1",
+              is_self: true,
+              created_utc: 1773057600, // 2026-03-09T12:00:00Z (0 hours ago)
+            },
+          },
+          {
+            data: {
+              id: "post2",
+              title: "[deleted]", // Deleted title
+              author: "user2",
+              score: 50,
+              num_comments: 10,
+              subreddit: "LocalLLaMA",
+              permalink: "/r/LocalLLaMA/comments/post2",
+              is_self: true,
+              created_utc: 1773054000, // 2026-03-09T11:00:00Z (1 hour ago)
+            },
+          },
+          {
+            data: {
+              id: "post3",
+              title: "Deleted Author Post",
+              author: "[deleted]", // Deleted author
+              score: 150,
+              num_comments: 30,
+              subreddit: "LocalLLaMA",
+              permalink: "/r/LocalLLaMA/comments/post3",
+              is_self: true,
+              created_utc: 1773050400, // 2026-03-09T10:00:00Z (2 hours ago)
+            },
+          },
+          {
+            data: {
+              id: "post4",
+              title: "Low Engagement Post",
+              author: "user4",
+              score: 1, // score < 2
+              num_comments: 0,
+              subreddit: "LocalLLaMA",
+              permalink: "/r/LocalLLaMA/comments/post4",
+              is_self: true,
+              created_utc: 1773057600,
+            },
+          },
+          {
+            data: {
+              id: "post5",
+              title: "Highly Discussed Older Post",
+              author: "user5",
+              score: 120,
+              num_comments: 80,
+              subreddit: "LocalLLaMA",
+              permalink: "/r/LocalLLaMA/comments/post5",
+              is_self: false,
+              url: "https://github.com/org/project",
+              created_utc: 1773043200, // 2026-03-09T08:00:00Z (4 hours ago)
+            },
+          },
+        ],
+      },
+    };
+
+    global.fetch = vi.fn().mockImplementation(() =>
+      Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve(mockResponse),
+      } as Response),
+    );
+
+    const result = await fetchRedditData(["LocalLLaMA"]);
+
+    expect(result.fetchSuccess).toBe(true);
+    expect(result.posts.length).toBe(2); // Only post1 and post5 pass filters
+
+    // Verify properties of mapped posts
+    const post1 = result.posts.find((p) => p.id === "post1");
+    expect(post1).toBeDefined();
+    expect(post1!.title).toBe("Normal Active Post");
+    expect(post1!.redditUrl).toBe("https://www.reddit.com/r/LocalLLaMA/comments/post1");
+    expect(post1!.url).toBe("https://www.reddit.com/r/LocalLLaMA/comments/post1"); // self post
+    expect(post1!.author).toBe("user1");
+    expect(post1!.score).toBe(100);
+    expect(post1!.comments).toBe(50);
+    expect(post1!.subreddit).toBe("LocalLLaMA");
+    expect(post1!.createdAt).toBe("2026-03-09T12:00:00.000Z");
+
+    const post5 = result.posts.find((p) => p.id === "post5");
+    expect(post5).toBeDefined();
+    expect(post5!.title).toBe("Highly Discussed Older Post");
+    expect(post5!.redditUrl).toBe("https://www.reddit.com/r/LocalLLaMA/comments/post5");
+    expect(post5!.url).toBe("https://github.com/org/project"); // external link
+    expect(post5!.externalLink).toBe("https://github.com/org/project");
+
+    // Let's verify ranking order.
+    // post1 ageHours = 0.
+    // score + comments * 3 = 100 + 50 * 3 = 250
+    // rankScore(post1) = 250 / Math.pow(0 + 2, 1.5) = 250 / 2.828 = 88.4
+    //
+    // post5 ageHours = 4.
+    // score + comments * 3 = 120 + 80 * 3 = 360
+    // rankScore(post5) = 360 / Math.pow(4 + 2, 1.5) = 360 / 14.697 = 24.5
+    //
+    // Thus post1 (88.4) should rank before post5 (24.5)
+    expect(result.posts[0]!.id).toBe("post1");
+    expect(result.posts[1]!.id).toBe("post5");
+  });
+
+  it("handles fetch failure gracefully", async () => {
+    global.fetch = vi.fn().mockImplementation(() =>
+      Promise.resolve({
+        ok: false,
+        status: 500,
+      } as Response),
+    );
+
+    const result = await fetchRedditData(["LocalLLaMA"]);
+    expect(result.fetchSuccess).toBe(false);
+    expect(result.posts.length).toBe(0);
+  });
+});

--- a/src/config.ts
+++ b/src/config.ts
@@ -19,11 +19,22 @@ interface RawRepoEntry {
   paginated?: boolean;
 }
 
+interface RawRedditConfig {
+  enabled?: boolean;
+  subreddits?: string[];
+}
+
+export interface RedditConfig {
+  enabled: boolean;
+  subreddits: string[];
+}
+
 interface RawConfig {
   cli_repos?: RawRepoEntry[];
   skills_repo?: string;
   openclaw?: RawRepoEntry;
   openclaw_peers?: RawRepoEntry[];
+  reddit?: RawRedditConfig;
 }
 
 export interface RadarConfig {
@@ -31,6 +42,7 @@ export interface RadarConfig {
   skillsRepo: string;
   openclaw: RepoConfig;
   openclawPeers: RepoConfig[];
+  reddit: RedditConfig;
 }
 
 // ---------------------------------------------------------------------------
@@ -72,6 +84,11 @@ const DEFAULT_OPENCLAW_PEERS: RepoConfig[] = [
   { id: "zeroclaw", repo: "zeroclaw-labs/zeroclaw", name: "ZeroClaw" },
 ];
 
+const DEFAULT_REDDIT: RedditConfig = {
+  enabled: false,
+  subreddits: ["LocalLLaMA"],
+};
+
 // ---------------------------------------------------------------------------
 // Loader
 // ---------------------------------------------------------------------------
@@ -90,6 +107,7 @@ export function loadConfig(configPath = "config.yml"): RadarConfig {
       skillsRepo: DEFAULT_SKILLS_REPO,
       openclaw: DEFAULT_OPENCLAW,
       openclawPeers: DEFAULT_OPENCLAW_PEERS,
+      reddit: DEFAULT_REDDIT,
     };
   }
 
@@ -112,10 +130,18 @@ export function loadConfig(configPath = "config.yml"): RadarConfig {
       ? raw.openclaw_peers.map(toRepoConfig)
       : DEFAULT_OPENCLAW_PEERS;
 
+  const reddit: RedditConfig = {
+    enabled: typeof raw?.reddit?.enabled === "boolean" ? raw.reddit.enabled : DEFAULT_REDDIT.enabled,
+    subreddits:
+      Array.isArray(raw?.reddit?.subreddits) && raw.reddit.subreddits.length > 0
+        ? raw.reddit.subreddits.map(String)
+        : DEFAULT_REDDIT.subreddits,
+  };
+
   console.log(
     `[config] Loaded from ${configPath}: ` +
-      `${cliRepos.length} CLI repos, ${openclawPeers.length} OpenClaw peers`,
+      `${cliRepos.length} CLI repos, ${openclawPeers.length} OpenClaw peers, Reddit is ${reddit.enabled ? "enabled" : "disabled"} (${reddit.subreddits.join(", ")})`,
   );
 
-  return { cliRepos, skillsRepo, openclaw, openclawPeers };
+  return { cliRepos, skillsRepo, openclaw, openclawPeers, reddit };
 }

--- a/src/generate-manifest.ts
+++ b/src/generate-manifest.ts
@@ -27,6 +27,8 @@ const REPORT_FILES = [
   "ai-hf-en",
   "ai-community",
   "ai-community-en",
+  "ai-reddit",
+  "ai-reddit-en",
   "ai-weekly",
   "ai-weekly-en",
   "ai-monthly",

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -99,6 +99,17 @@ export const COMMUNITY_REPORT = {
     lang === "en" ? `💬 Tech Community AI Digest ${dateStr}` : `💬 技术社区 AI 动态日报 ${dateStr}`,
 } as const;
 
+export const REDDIT_REPORT = {
+  title: t("Reddit AI 社区动态日报", "Reddit AI Community Digest"),
+  issueTitle: (dateStr: string, lang: Lang) =>
+    lang === "en" ? `🤖 Reddit AI Digest ${dateStr}` : `🤖 Reddit AI 社区动态日报 ${dateStr}`,
+  metadata: (count: number, subreddits: string[], utcStr: string, lang: Lang) =>
+    lang === "en"
+      ? `> Source: Reddit (${subreddits.join(", ")}) | ${count} posts analyzed | Generated: ${utcStr} UTC`
+      : `> 数据来源: Reddit (${subreddits.join(", ")}) | 共分析 ${count} 篇帖子 | 生成时间: ${utcStr} UTC`,
+  labels: t("reddit", "reddit-en"),
+} as const;
+
 export const WEEKLY_REPORT = {
   title: t("AI 工具生态周报", "AI Tools Ecosystem Weekly Report"),
   coverage: t("覆盖日期", "Coverage"),
@@ -120,6 +131,7 @@ export const ISSUE_LABELS = {
   arxiv: t("arxiv", "arxiv-en"),
   hf: t("hf", "hf-en"),
   community: t("community", "community-en"),
+  reddit: t("reddit", "reddit-en"),
 } as const;
 
 export const CLI_ISSUE_TITLE = (dateStr: string, lang: Lang) =>
@@ -163,6 +175,8 @@ export const REPORT_LABELS: Record<string, string> = {
   "ai-hf-en": "Hugging Face Trending Models Digest",
   "ai-community": "技术社区 AI 动态日报",
   "ai-community-en": "Tech Community AI Digest",
+  "ai-reddit": "Reddit AI 社区动态日报",
+  "ai-reddit-en": "Reddit AI Community Digest",
   "ai-weekly": "AI 工具生态周报",
   "ai-weekly-en": "AI Tools Weekly Digest",
   "ai-monthly": "AI 工具生态月报",
@@ -179,6 +193,7 @@ export const NOTIFY_LABELS: Record<string, Record<Lang, string>> = {
   "ai-arxiv": t("ArXiv 研究", "ArXiv Research"),
   "ai-hf": t("HF 模型", "HF Models"),
   "ai-community": t("技术社区", "Tech Community"),
+  "ai-reddit": t("Reddit 社区", "Reddit Community"),
   "ai-weekly": t("AI 工具生态周报", "AI Tools Weekly"),
   "ai-monthly": t("AI 工具生态月报", "AI Tools Monthly"),
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,6 +9,7 @@
  * Provider-specific env vars — see src/providers/ for full list.
  */
 
+import "dotenv/config";
 import fs from "node:fs";
 import path from "node:path";
 import {
@@ -38,6 +39,7 @@ import {
   saveArxivReport,
   saveHfReport,
   saveCommunityReport,
+  saveRedditReport,
 } from "./report-savers.ts";
 import { loadWebState, fetchSiteContent, type WebFetchResult, type WebState } from "./web.ts";
 import { fetchTrendingData, type TrendingData } from "./trending.ts";
@@ -47,6 +49,7 @@ import { fetchArxivData, type ArxivData } from "./arxiv.ts";
 import { fetchHfData, type HfData } from "./hf.ts";
 import { fetchDevtoData, type DevtoData } from "./devto.ts";
 import { fetchLobstersData, type LobstersData } from "./lobsters.ts";
+import { fetchRedditData, type RedditData } from "./reddit.ts";
 import { loadConfig } from "./config.ts";
 import { toCstDateStr, toUtcStr } from "./date.ts";
 import { type Lang, MSG, ISSUE_LABELS, CLI_ISSUE_TITLE, OPENCLAW_ISSUE_TITLE } from "./i18n.ts";
@@ -60,6 +63,7 @@ const {
   skillsRepo: CLAUDE_SKILLS_REPO,
   openclaw: OPENCLAW,
   openclawPeers: OPENCLAW_PEERS,
+  reddit: REDDIT_CONFIG,
 } = loadConfig();
 
 // ---------------------------------------------------------------------------
@@ -79,6 +83,7 @@ function requireEnv(name: string): string {
 async function fetchAllData(
   since: Date,
   webState: WebState,
+  subreddits: string[],
 ): Promise<{
   fetched: RepoFetch[];
   skillsData: { prs: GitHubItem[]; issues: GitHubItem[] };
@@ -90,10 +95,11 @@ async function fetchAllData(
   hfData: HfData;
   devtoData: DevtoData;
   lobstersData: LobstersData;
+  redditData: RedditData;
 }> {
   const allConfigs = [...CLI_REPOS, OPENCLAW, ...OPENCLAW_PEERS];
   console.log(
-    `  Tracking: ${allConfigs.map((r) => r.id).join(", ")}, claude-code-skills, web, hn, ph, arxiv, hf, devto, lobsters`,
+    `  Tracking: ${allConfigs.map((r) => r.id).join(", ")}, claude-code-skills, web, hn, ph, arxiv, hf, devto, lobsters, reddit`,
   );
 
   const [
@@ -107,6 +113,7 @@ async function fetchAllData(
     hfData,
     devtoData,
     lobstersData,
+    redditData,
   ] = await Promise.all([
     Promise.all(
       allConfigs.map(async (cfg) => {
@@ -165,6 +172,9 @@ async function fetchAllData(
     fetchHfData().catch((): HfData => ({ models: [], fetchSuccess: false })),
     fetchDevtoData().catch((): DevtoData => ({ articles: [], fetchSuccess: false })),
     fetchLobstersData().catch((): LobstersData => ({ stories: [], fetchSuccess: false })),
+    REDDIT_CONFIG.enabled
+      ? fetchRedditData(subreddits).catch((): RedditData => ({ posts: [], fetchSuccess: false }))
+      : Promise.resolve({ posts: [], fetchSuccess: false }),
   ]);
 
   return {
@@ -178,6 +188,7 @@ async function fetchAllData(
     hfData,
     devtoData,
     lobstersData,
+    redditData,
   };
 }
 
@@ -311,7 +322,8 @@ async function main(): Promise<void> {
     hfData,
     devtoData,
     lobstersData,
-  } = await fetchAllData(since, webState);
+    redditData,
+  } = await fetchAllData(since, webState, REDDIT_CONFIG.subreddits);
 
   const peerIds = new Set(OPENCLAW_PEERS.map((p) => p.id));
   const fetchedCli = fetched.filter((f) => f.cfg.id !== OPENCLAW.id && !peerIds.has(f.cfg.id));
@@ -417,6 +429,8 @@ async function main(): Promise<void> {
     saveHfReport(hfData, utcStr, dateStr, digestRepo, autoGenFooter("en"), "en"),
     saveCommunityReport(devtoData, lobstersData, utcStr, dateStr, digestRepo, autoGenFooter("zh"), "zh"),
     saveCommunityReport(devtoData, lobstersData, utcStr, dateStr, digestRepo, autoGenFooter("en"), "en"),
+    REDDIT_CONFIG.enabled ? saveRedditReport(redditData, REDDIT_CONFIG.subreddits, utcStr, dateStr, digestRepo, autoGenFooter("zh"), "zh") : Promise.resolve(),
+    REDDIT_CONFIG.enabled ? saveRedditReport(redditData, REDDIT_CONFIG.subreddits, utcStr, dateStr, digestRepo, autoGenFooter("en"), "en") : Promise.resolve(),
   ]);
 
   // 5. Generate highlights for Telegram notification
@@ -435,6 +449,7 @@ async function main(): Promise<void> {
     ["ai-arxiv", "ai-arxiv.md", "ai-arxiv-en.md"],
     ["ai-hf", "ai-hf.md", "ai-hf-en.md"],
     ["ai-community", "ai-community.md", "ai-community-en.md"],
+    ["ai-reddit", "ai-reddit.md", "ai-reddit-en.md"],
   ] as const) {
     const zh = readReport(zhFile);
     const en = readReport(enFile);

--- a/src/prompts-data.ts
+++ b/src/prompts-data.ts
@@ -13,6 +13,7 @@ import type { ArxivData } from "./arxiv.ts";
 import type { HfData } from "./hf.ts";
 import type { DevtoData } from "./devto.ts";
 import type { LobstersData } from "./lobsters.ts";
+import type { RedditData } from "./reddit.ts";
 import type { Lang } from "./i18n.ts";
 export function buildTrendingPrompt(data: TrendingData, dateStr: string, lang: Lang = "zh"): string {
   const trendingSection =
@@ -906,3 +907,81 @@ ${lobstersText}
 语言要求：中文，简洁专业，保留所有原文链接。
 `;
 }
+
+export function buildRedditPrompt(data: RedditData, dateStr: string, lang: Lang = "zh"): string {
+  const postsText = data.posts
+    .map((p, i) => {
+      const textSnippet = p.postText 
+        ? `\n   Text Snippet: ${p.postText.slice(0, 300)}${p.postText.length > 300 ? "..." : ""}`
+        : "";
+      const extLink = p.externalLink ? `\n   External Link: ${p.externalLink}` : "";
+      
+      return lang === "en"
+        ? `${i + 1}. **${p.title}** (r/${p.subreddit})\n` +
+          `   Discussion: ${p.redditUrl}${extLink}\n` +
+          `   Score: ${p.score} | Comments: ${p.comments} | Author: ${p.author} | Time: ${p.createdAt.slice(0, 16)}${textSnippet}`
+        : `${i + 1}. **${p.title}** (r/${p.subreddit})\n` +
+          `   讨论: ${p.redditUrl}${extLink}\n` +
+          `   分数: ${p.score} | 评论: ${p.comments} | 作者: ${p.author} | 时间: ${p.createdAt.slice(0, 16)}${textSnippet}`;
+    })
+    .join("\n\n");
+
+  if (lang === "en") {
+    return `You are a professional AI technology analyst and community researcher. The following are trending and high-engagement posts from AI-related subreddits (such as r/LocalLLaMA) in the past 24 hours as of ${dateStr} (sorted by custom engagement/recency score, ${data.posts.length} total):
+
+---
+
+${postsText}
+
+---
+
+Generate a highly structured Reddit AI Community Digest in English:
+
+1. **Today's Highlights** — 3-5 sentences summarizing the most critical discussions, trends, and breakthroughs on Reddit today.
+
+2. **Key Insights by Category** — Categorize the most noteworthy posts and extract their core signals. Avoid simply listing the posts. Instead, summarize what they mean, include links, scores, comments, and the subreddit context. Identify findings under these headings:
+   - 💬 Top Discussions (significant technical threads, arguments, community thoughts)
+   - 🧠 Model Releases & Fine-Tuning (new models, open-weights releases, quantization updates, fine-tuning results)
+   - 🛠️ Tooling & Infrastructure (inference engines, local AI tooling, RAG, agent frameworks, hardware optimization)
+   - 🔬 Research & Experiments (notable papers, benchmark results, user experiments)
+
+3. **Community Sentiment & Pulse** — 150-250 words analyzing what the community is excited, concerned, or debating about today:
+   - What are the dominant consensus points or hot debates?
+   - Any emergent tech stacks or challenges appearing for AI engineers?
+   - Practical developer sentiment about newly released tools.
+
+4. **Actionable Takeaways** — A bulleted list of 3-5 specific signals, projects, or practices that AI engineers and software developers should pay close attention to, with brief developer-focused reasoning.
+
+Style: English, professional, analytical, concise, and focused on insight extraction. Ensure all original Reddit links (discussion links) and external links are preserved.
+`;
+  }
+
+  return `你是一位专业的 AI 技术分析师和社区研究员。以下是 ${dateStr} 从 AI 相关 Reddit 社区（如 r/LocalLLaMA）抓取的过去 24 小时内热门且高互动的帖子（按自定义的热度与时效性得分降序，共 ${data.posts.length} 条）：
+
+---
+
+${postsText}
+
+---
+
+请生成一份结构清晰、分析深入的《Reddit AI 社区动态日报》，要求：
+
+1. **今日速览** — 3~5 句话，概括今日 Reddit 社区最核心的讨论方向、前沿趋势或重大突破。
+
+2. **热门讨论与技术信号** — 避免简单罗列帖子，请按以下分类进行整合和提炼，深入分析其背后的核心价值、社区反馈与影响，并包含原文/讨论链接、subreddit 标识以及分数/评论数：
+   - 💬 深度社区热议（重点技术讨论、行业观点争议、社区思想碰撞）
+   - 🧠 模型发布与微调（新模型及开源权重发布、量化更新、微调成效、评测结果）
+   - 🛠️ 工具链与基础设施（推理引擎、本地 AI 工具、RAG、Agent 框架、硬件优化）
+   - 🔬 研究与前沿实验（值得关注的论文分享、用户自测基准、新奇探索）
+
+3. **社区情绪与技术脉搏** — 150~250 字，剖析今日 Reddit 社区的整体情绪和热点议题：
+   - 社区对哪些话题达成了共识，又在争论什么？
+   - 开发者在使用最新工具时遇到了哪些实际痛点或带来了哪些新思路？
+   - 透露出哪些潜在的技术演进方向？
+
+4. **开发者行动指南** — 以 bullet 形式列出 3~5 条最值得 AI 工程师/软件开发者重点跟进的具体项目、工具或实践，并给出硬核的技术理由。
+
+语言要求：中文，专业硬核，简洁清晰，每个条目必须保留所有 Reddit 讨论链接和外部链接。
+`;
+}
+

--- a/src/reddit.ts
+++ b/src/reddit.ts
@@ -1,0 +1,152 @@
+/**
+ * Reddit AI community posts fetched via public JSON endpoints (e.g., r/LocalLLaMA/hot.json).
+ */
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface RedditPost {
+  id: string;
+  title: string;
+  url: string; // external URL, or Reddit discussion link if self-post
+  redditUrl: string; // always the Reddit discussion link (permalink)
+  author: string;
+  score: number;
+  comments: number;
+  subreddit: string;
+  createdAt: string;
+  postText?: string;
+  externalLink?: string;
+}
+
+export interface RedditData {
+  posts: RedditPost[];
+  fetchSuccess: boolean;
+}
+
+interface RedditApiResponse {
+  data?: {
+    children?: Array<{
+      data?: {
+        id?: string;
+        title?: string;
+        author?: string;
+        selftext?: string;
+        removed?: boolean;
+        score?: number;
+        num_comments?: number;
+        permalink?: string;
+        is_self?: boolean;
+        url?: string;
+        created_utc?: number;
+        stickied?: boolean;
+        subreddit?: string;
+      };
+    }>;
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const REDDIT_TOP_POSTS = 30;
+
+// ---------------------------------------------------------------------------
+// Fetch & Process
+// ---------------------------------------------------------------------------
+
+/**
+ * Fetches hot posts from specified subreddits, filters, ranks, and returns the top results.
+ * @param subreddits List of subreddits to fetch from (defaults to ["LocalLLaMA"])
+ */
+export async function fetchRedditData(subreddits: string[] = ["LocalLLaMA"]): Promise<RedditData> {
+  const targetSubreddits = subreddits.length > 0 ? subreddits : ["LocalLLaMA"];
+  const seen = new Map<string, RedditPost & { rankScore: number }>();
+
+  try {
+    await Promise.all(
+      targetSubreddits.map(async (sub) => {
+        try {
+          const url = `https://www.reddit.com/r/${sub}/hot.json?limit=50`;
+          const resp = await fetch(url, {
+            headers: {
+              // Use a compliant, unique User-Agent per Reddit API rules to bypass Cloudflare anti-bot block
+              "User-Agent": "node:agents-radar:v1.0.0 (by /u/bharatvarma6222)",
+            },
+          });
+
+          if (!resp.ok) {
+            console.error(`  [reddit] r/${sub}: HTTP ${resp.status}`);
+            return;
+          }
+
+          const raw = (await resp.json()) as RedditApiResponse;
+          const children = raw?.data?.children ?? [];
+
+          for (const child of children) {
+            const p = child?.data;
+            if (!p || !p.id) continue;
+
+            // 1. Filter out deleted or removed posts
+            const isDeleted =
+              p.author === "[deleted]" || p.selftext === "[deleted]" || p.title === "[deleted]";
+            const isRemoved = p.selftext === "[removed]" || p.title === "[removed]" || p.removed === true;
+            if (isDeleted || isRemoved) continue;
+
+            // 2. Filter out extremely low-engagement posts (e.g. score < 2)
+            const score = p.score ?? 0;
+            if (score < 2) continue;
+
+            // 3. Extract properties
+            const redditUrl = `https://www.reddit.com${p.permalink}`;
+            const externalLink = !p.is_self && p.url && !p.url.includes("reddit.com") ? p.url : undefined;
+            const finalUrl = externalLink || redditUrl;
+            const comments = p.num_comments ?? 0;
+            const createdAt = new Date((p.created_utc ?? Date.now() / 1000) * 1000).toISOString();
+
+            // 4. Calculate ranking score:
+            // R = (Upvotes + Comments * 3) / (AgeInHours + 2)^1.5
+            // This prioritizes recent highly-discussed posts over old viral posts.
+            const ageHours = Math.max(0, (Date.now() - new Date(createdAt).getTime()) / (1000 * 60 * 60));
+            const rankScore = (score + comments * 3) / Math.pow(ageHours + 2, 1.5);
+
+            if (!seen.has(p.id)) {
+              seen.set(p.id, {
+                id: p.id,
+                title: p.title || "",
+                url: finalUrl,
+                redditUrl,
+                author: p.author || "",
+                score,
+                comments,
+                subreddit: p.subreddit || sub,
+                createdAt,
+                postText: p.selftext || undefined,
+                externalLink,
+                rankScore,
+              });
+            }
+          }
+        } catch (err) {
+          console.error(`  [reddit] r/${sub} fetch failed: ${err}`);
+        }
+      }),
+    );
+
+    // Sort by rankScore descending and slice top posts
+    const sortedPosts = [...seen.values()]
+      .sort((a, b) => b.rankScore - a.rankScore)
+      .slice(0, REDDIT_TOP_POSTS);
+
+    // Remove the rankScore property for the public interface
+    const posts: RedditPost[] = sortedPosts.map(({ rankScore: _rankScore, ...post }) => post);
+
+    console.log(`  [reddit] ${posts.length} posts (from ${seen.size} unique)`);
+    return { posts, fetchSuccess: posts.length > 0 };
+  } catch (err) {
+    console.error(`  [reddit] general fetch failed: ${err}`);
+    return { posts: [], fetchSuccess: false };
+  }
+}

--- a/src/report-savers.ts
+++ b/src/report-savers.ts
@@ -12,6 +12,7 @@ import {
   ARXIV_REPORT,
   HF_REPORT,
   COMMUNITY_REPORT,
+  REDDIT_REPORT,
   ISSUE_LABELS,
 } from "./i18n.ts";
 import {
@@ -21,6 +22,7 @@ import {
   buildArxivPrompt,
   buildHfPrompt,
   buildCommunityPrompt,
+  buildRedditPrompt,
 } from "./prompts-data.ts";
 import { callLlm, saveFile, LLM_TOKENS_WEB } from "./report.ts";
 import { createGitHubIssue } from "./github.ts";
@@ -32,6 +34,7 @@ import type { ArxivData } from "./arxiv.ts";
 import type { HfData } from "./hf.ts";
 import type { DevtoData } from "./devto.ts";
 import type { LobstersData } from "./lobsters.ts";
+import type { RedditData } from "./reddit.ts";
 
 // ---------------------------------------------------------------------------
 // Web report
@@ -369,3 +372,47 @@ export async function saveCommunityReport(
     console.error(`  [community/${lang}] Report generation failed: ${err}`);
   }
 }
+
+// ---------------------------------------------------------------------------
+// Reddit report
+// ---------------------------------------------------------------------------
+
+export async function saveRedditReport(
+  redditData: RedditData,
+  subreddits: string[],
+  utcStr: string,
+  dateStr: string,
+  digestRepo: string,
+  footer: string,
+  lang: Lang = "zh",
+): Promise<void> {
+  if (!redditData.fetchSuccess || redditData.posts.length === 0) {
+    console.log(`  [reddit/${lang}] No data available, skipping report.`);
+    return;
+  }
+
+  console.log(`  [reddit/${lang}] Calling LLM for Reddit report...`);
+  try {
+    const summary = await callLlm(buildRedditPrompt(redditData, dateStr, lang));
+    const fileName = lang === "en" ? "ai-reddit-en.md" : "ai-reddit.md";
+    
+    const header =
+      `# ${REDDIT_REPORT.title[lang]} ${dateStr}\n\n` +
+      `${REDDIT_REPORT.metadata(redditData.posts.length, subreddits, utcStr, lang)}\n\n` +
+      `---\n\n`;
+
+    const content = header + summary + footer;
+
+    console.log(`  Saved ${saveFile(content, dateStr, fileName)}`);
+
+    if (digestRepo) {
+      const title = REDDIT_REPORT.issueTitle(dateStr, lang);
+      const label = ISSUE_LABELS.reddit[lang];
+      const url = await createGitHubIssue(title, content, label);
+      console.log(`  Created Reddit issue (${lang}): ${url}`);
+    }
+  } catch (err) {
+    console.error(`  [reddit/${lang}] Report generation failed: ${err}`);
+  }
+}
+

--- a/src/rollup.ts
+++ b/src/rollup.ts
@@ -20,7 +20,7 @@ const DIGESTS_DIR = "digests";
 const MAX_CHARS_PER_REPORT = 2500;
 
 // Source report types to read for rollups (in priority order)
-const ROLLUP_SOURCES = ["ai-cli", "ai-agents", "ai-trending", "ai-hn", "ai-web"];
+const ROLLUP_SOURCES = ["ai-cli", "ai-agents", "ai-trending", "ai-hn", "ai-web", "ai-reddit"];
 
 // ---------------------------------------------------------------------------
 // Helpers


### PR DESCRIPTION
### Summary
This PR adds Reddit as a first-class data source to the Agents Radar pipeline, starting with the **r/LocalLLaMA** subreddit. It integrates data collection, localized prompt building, report saving, and weekly/monthly rollup summaries.

### Key Changes
* **Reddit Ingestion Pipeline (`src/reddit.ts`)**:
  - Implements sequential/parallel fetches from subreddit `.json` endpoints.
  - Utilizes a unique, compliant Reddit User-Agent to bypass strict Cloudflare anti-bot blocks.
  - Implements robust filters to strip out deleted, removed, and low-engagement posts.
  - Implements a custom ranking formula that balances upvotes, comments, and recency:
    $$\text{Rank Score} = \frac{\text{score} + \text{comments} \times 3}{\text{ageHours} + 2^{1.5}}$$
* **Configuration (`config.yml` & `src/config.ts`)**:
  - Added support in `config.yml` to enable/disable Reddit and list subreddits under the `reddit` key.
* **Pipeline Integration (`src/index.ts` & `src/rollup.ts`)**:
  - Integrated into daily ingestion, LLM summary saving, and Highlights/Telegram notification pipelines.
  - Linked daily Reddit digest reports to weekly and monthly rollup sources.
* **Internationalization (`src/i18n.ts` & `src/prompts-data.ts`)**:
  - Configured bilingual (Chinese/English) headers, issue titles, RSS tags, and LLM prompt templates.
* **Test Coverage**:
  - Added full test suite in `src/__tests__/reddit.test.ts` (mocking the global fetch, testing filters, and ranking correctness).
  - Added prompt-builder tests in `src/__tests__/prompt-builders.test.ts`.

### Verification Results
* Successfully ran local dry-runs verifying graceful degradation (e.g. logging and continuing without crashing when HTTP 403 occurs).
* All new and existing tests passed:
  - `npx vitest run src/__tests__/reddit.test.ts` (2/2 passed)
  - `npx vitest run src/__tests__/prompt-builders.test.ts` (24/24 passed)
