### PR TITLE
feat: add Evolink LLM provider

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,3 +2,4 @@
 # LLM_PROVIDER=anthropic
 ANTHROPIC_API_KEY=sk-ant-xxxxx
 # OPENAI_API_KEY=sk-xxxxx
+# EVOLINK_API_KEY=evl-xxxxx

--- a/README.md
+++ b/README.md
@@ -221,12 +221,14 @@ Go to **Settings → Secrets and variables → Actions** and add:
 
 | Secret | Required | Description |
 |--------|----------|-------------|
-| `LLM_PROVIDER` | optional | `anthropic` (default), `openai`, `github-copilot`, or `openrouter` |
+| `LLM_PROVIDER` | optional | `anthropic` (default), `openai`, `github-copilot`, `openrouter`, `deepseek`, or `evolink` |
 | `ANTHROPIC_API_KEY` | if Anthropic | API key — works with both Anthropic and Kimi Code |
 | `ANTHROPIC_BASE_URL` | optional | API endpoint override. Set to `https://api.kimi.com/coding/` for Kimi Code; leave unset for Anthropic |
 | `OPENAI_API_KEY` | if OpenAI | OpenAI API key |
 | `OPENAI_BASE_URL` | optional | OpenAI endpoint override |
 | `OPENROUTER_API_KEY` | if OpenRouter | OpenRouter API key |
+| `DEEPSEEK_API_KEY` | if DeepSeek | DeepSeek API key |
+| `EVOLINK_API_KEY` | if Evolink | Evolink API key |
 | `TELEGRAM_BOT_TOKEN` | optional | Telegram bot token from [@BotFather](https://t.me/BotFather). If set, a message is sent after each digest run |
 | `TELEGRAM_CHAT_ID` | optional | Telegram chat/channel/group ID to send notifications to |
 | `FEISHU_WEBHOOK_URLS` | optional | Comma-separated Feishu custom bot webhook URLs. If set, a card message is sent to each group after each digest run |
@@ -259,8 +261,10 @@ Set `LLM_PROVIDER` to choose which model backend powers the digest generation. D
 | OpenAI | `openai` | `OPENAI_API_KEY` | `gpt-4o` |
 | GitHub Copilot | `github-copilot` | `GITHUB_TOKEN` | `gpt-4o` |
 | OpenRouter | `openrouter` | `OPENROUTER_API_KEY` | `anthropic/claude-sonnet-4` |
+| DeepSeek | `deepseek` | `DEEPSEEK_API_KEY` | `deepseek-chat` |
+| Evolink | `evolink` | `EVOLINK_API_KEY` | `gpt-5.2` |
 
-Override the model name with `ANTHROPIC_MODEL`, `OPENAI_MODEL`, `GITHUB_COPILOT_MODEL`, or `OPENROUTER_MODEL` respectively.
+Override the model name with `ANTHROPIC_MODEL`, `OPENAI_MODEL`, `GITHUB_COPILOT_MODEL`, `OPENROUTER_MODEL`, `DEEPSEEK_MODEL`, or `EVOLINK_MODEL` respectively.
 
 The provider abstraction lives in `src/providers/` — each provider is a separate file implementing the `LlmProvider` interface. Adding a new provider only requires creating a new file and registering it in the factory.
 
@@ -284,6 +288,10 @@ export ANTHROPIC_API_KEY=sk-ant-xxxxxxxx
 # Option D: OpenRouter
 # export LLM_PROVIDER=openrouter
 # export OPENROUTER_API_KEY=sk-or-xxxxxxxx
+
+# Option E: Evolink
+# export LLM_PROVIDER=evolink
+# export EVOLINK_API_KEY=evl-xxxxxxxx
 
 export DIGEST_REPO=your-username/agents-radar  # optional; omit to only write files
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -220,12 +220,14 @@ openclaw_peers:
 
 | Secret | 必填 | 说明 |
 |--------|------|------|
-| `LLM_PROVIDER` | 可选 | `anthropic`（默认）、`openai`、`github-copilot` 或 `openrouter` |
+| `LLM_PROVIDER` | 可选 | `anthropic`（默认）、`openai`、`github-copilot`、`openrouter`、`deepseek` 或 `evolink` |
 | `ANTHROPIC_API_KEY` | Anthropic 时 | API 密钥，兼容 Anthropic 和 Kimi Code |
 | `ANTHROPIC_BASE_URL` | 可选 | API 地址覆盖。使用 Kimi Code 时设置为 `https://api.kimi.com/coding/`，使用 Anthropic 时留空 |
 | `OPENAI_API_KEY` | OpenAI 时 | OpenAI API 密钥 |
 | `OPENAI_BASE_URL` | 可选 | OpenAI 端点覆盖 |
 | `OPENROUTER_API_KEY` | OpenRouter 时 | OpenRouter API 密钥 |
+| `DEEPSEEK_API_KEY` | DeepSeek 时 | DeepSeek API 密钥 |
+| `EVOLINK_API_KEY` | Evolink 时 | Evolink API 密钥 |
 | `TELEGRAM_BOT_TOKEN` | 可选 | Telegram bot token，从 [@BotFather](https://t.me/BotFather) 获取。设置后每次 digest 完成自动推送通知 |
 | `TELEGRAM_CHAT_ID` | 可选 | 接收通知的 Telegram 频道 / 群组 / 用户 ID |
 | `FEISHU_WEBHOOK_URLS` | 可选 | 飞书自定义机器人 Webhook URL，多个用英文逗号分隔。设置后每次 digest 完成自动推送卡片通知到所有群 |
@@ -258,8 +260,10 @@ openclaw_peers:
 | OpenAI | `openai` | `OPENAI_API_KEY` | `gpt-4o` |
 | GitHub Copilot | `github-copilot` | `GITHUB_TOKEN` | `gpt-4o` |
 | OpenRouter | `openrouter` | `OPENROUTER_API_KEY` | `anthropic/claude-sonnet-4` |
+| DeepSeek | `deepseek` | `DEEPSEEK_API_KEY` | `deepseek-chat` |
+| Evolink | `evolink` | `EVOLINK_API_KEY` | `gpt-5.2` |
 
-可通过 `ANTHROPIC_MODEL`、`OPENAI_MODEL`、`GITHUB_COPILOT_MODEL` 或 `OPENROUTER_MODEL` 分别覆盖默认模型名称。
+可通过 `ANTHROPIC_MODEL`、`OPENAI_MODEL`、`GITHUB_COPILOT_MODEL`、`OPENROUTER_MODEL`、`DEEPSEEK_MODEL` 或 `EVOLINK_MODEL` 分别覆盖默认模型名称。
 
 Provider 抽象层位于 `src/providers/`，每个供应商对应独立文件并实现 `LlmProvider` 接口。新增供应商只需创建新文件并在工厂函数中注册。
 
@@ -283,6 +287,10 @@ export ANTHROPIC_API_KEY=sk-ant-xxxxxxxx
 # 方式 D: OpenRouter
 # export LLM_PROVIDER=openrouter
 # export OPENROUTER_API_KEY=sk-or-xxxxxxxx
+
+# 方式 E: Evolink
+# export LLM_PROVIDER=evolink
+# export EVOLINK_API_KEY=evl-xxxxxxxx
 
 export DIGEST_REPO=your-username/agents-radar  # 可选，留空则仅写入本地文件
 

--- a/src/__tests__/providers.test.ts
+++ b/src/__tests__/providers.test.ts
@@ -4,6 +4,8 @@ import {
   OpenAIProvider,
   GitHubCopilotProvider,
   OpenRouterProvider,
+  DeepSeekProvider,
+  EvolinkProvider,
   createProvider,
   VALID_PROVIDER_NAMES,
   type LlmProvider,
@@ -100,12 +102,24 @@ describe("LlmProvider interface", () => {
     expect(p.name).toBe("openrouter");
   });
 
+  it("DeepSeekProvider has correct name", () => {
+    const p = new DeepSeekProvider({ apiKey: "test" });
+    expect(p.name).toBe("deepseek");
+  });
+
+  it("EvolinkProvider has correct name", () => {
+    const p = new EvolinkProvider({ apiKey: "test" });
+    expect(p.name).toBe("evolink");
+  });
+
   it("all providers implement LlmProvider with call()", () => {
     const providers: LlmProvider[] = [
       new AnthropicProvider(),
       new OpenAIProvider({ apiKey: "k" }),
       new GitHubCopilotProvider({ apiKey: "k" }),
       new OpenRouterProvider({ apiKey: "k" }),
+      new DeepSeekProvider({ apiKey: "k" }),
+      new EvolinkProvider({ apiKey: "k" }),
     ];
     for (const p of providers) {
       expect(typeof p.name).toBe("string");
@@ -119,8 +133,15 @@ describe("LlmProvider interface", () => {
 // ---------------------------------------------------------------------------
 
 describe("VALID_PROVIDER_NAMES", () => {
-  it("contains all five supported providers", () => {
-    expect(VALID_PROVIDER_NAMES).toEqual(["anthropic", "openai", "github-copilot", "openrouter", "deepseek"]);
+  it("contains all six supported providers", () => {
+    expect(VALID_PROVIDER_NAMES).toEqual([
+      "anthropic",
+      "openai",
+      "github-copilot",
+      "openrouter",
+      "deepseek",
+      "evolink",
+    ]);
   });
 });
 
@@ -314,6 +335,45 @@ describe("OpenRouterProvider", () => {
 });
 
 // ---------------------------------------------------------------------------
+// EvolinkProvider
+// ---------------------------------------------------------------------------
+
+describe("EvolinkProvider", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("call returns text", async () => {
+    const mockCreate = await getOpenAIMockCreate();
+    mockCreate.mockResolvedValueOnce({
+      choices: [{ message: { content: "Hello from Evolink" } }],
+    });
+
+    const p = new EvolinkProvider({ apiKey: "evl_test" });
+    const result = await p.call("prompt", 256);
+    expect(result).toBe("Hello from Evolink");
+  });
+
+  it(
+    "uses EVOLINK_MODEL env",
+    withEnv({ EVOLINK_MODEL: "deepseek-v4-pro" }, () => {
+      const p = new EvolinkProvider({ apiKey: "k" });
+      expect(p.name).toBe("evolink");
+    }),
+  );
+
+  it("throws on empty response", async () => {
+    const mockCreate = await getOpenAIMockCreate();
+    mockCreate.mockResolvedValueOnce({
+      choices: [{ message: { content: "" } }],
+    });
+
+    const p = new EvolinkProvider({ apiKey: "k" });
+    await expect(p.call("prompt", 100)).rejects.toThrow("Unexpected empty response from evolink");
+  });
+});
+
+// ---------------------------------------------------------------------------
 // createProvider factory
 // ---------------------------------------------------------------------------
 
@@ -353,6 +413,16 @@ describe("createProvider", () => {
   it("creates openrouter provider", () => {
     const p = createProvider("openrouter");
     expect(p).toBeInstanceOf(OpenRouterProvider);
+  });
+
+  it("creates deepseek provider", () => {
+    const p = createProvider("deepseek");
+    expect(p).toBeInstanceOf(DeepSeekProvider);
+  });
+
+  it("creates evolink provider", () => {
+    const p = createProvider("evolink");
+    expect(p).toBeInstanceOf(EvolinkProvider);
   });
 
   it(

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,7 +2,7 @@
  * agents-radar: daily digest for AI CLI tools and OpenClaw.
  *
  * Env vars:
- *   LLM_PROVIDER        - "anthropic" | "openai" | "github-copilot" | "openrouter" (default: anthropic)
+ *   LLM_PROVIDER        - "anthropic" | "openai" | "github-copilot" | "openrouter" | "deepseek" | "evolink" (default: anthropic)
  *   GITHUB_TOKEN        - GitHub token for API access and issue creation
  *   DIGEST_REPO         - owner/repo where digest issues are posted (optional)
  *

--- a/src/providers/evolink.ts
+++ b/src/providers/evolink.ts
@@ -1,0 +1,23 @@
+/**
+ * Evolink provider — OpenAI-compatible endpoint via direct.evolink.ai.
+ *
+ * Env vars:
+ *   EVOLINK_API_KEY  - API key
+ *   EVOLINK_MODEL    - model name (default: gpt-5.2)
+ */
+
+import { OpenAICompatibleProvider } from "./openai-compatible.ts";
+
+const EVOLINK_BASE_URL = "https://direct.evolink.ai/v1";
+
+export class EvolinkProvider extends OpenAICompatibleProvider {
+  readonly name = "evolink";
+
+  constructor(opts?: { apiKey?: string; model?: string }) {
+    super({
+      apiKey: opts?.apiKey ?? process.env["EVOLINK_API_KEY"],
+      baseURL: EVOLINK_BASE_URL,
+      model: opts?.model ?? process.env["EVOLINK_MODEL"] ?? "gpt-5.2",
+    });
+  }
+}

--- a/src/providers/index.ts
+++ b/src/providers/index.ts
@@ -12,6 +12,7 @@ export { OpenAIProvider } from "./openai.ts";
 export { GitHubCopilotProvider } from "./github-copilot.ts";
 export { OpenRouterProvider } from "./openrouter.ts";
 export { DeepSeekProvider } from "./deepseek.ts";
+export { EvolinkProvider } from "./evolink.ts";
 
 import type { LlmProvider, ProviderFactory } from "./types.ts";
 import { AnthropicProvider } from "./anthropic.ts";
@@ -19,6 +20,7 @@ import { OpenAIProvider } from "./openai.ts";
 import { GitHubCopilotProvider } from "./github-copilot.ts";
 import { OpenRouterProvider } from "./openrouter.ts";
 import { DeepSeekProvider } from "./deepseek.ts";
+import { EvolinkProvider } from "./evolink.ts";
 
 // ---------------------------------------------------------------------------
 // Single source of truth — add new providers here only.
@@ -30,6 +32,7 @@ const PROVIDERS = {
   "github-copilot": () => new GitHubCopilotProvider(),
   openrouter: () => new OpenRouterProvider(),
   deepseek: () => new DeepSeekProvider(),
+  evolink: () => new EvolinkProvider(),
 } satisfies Record<string, ProviderFactory>;
 
 /** Supported provider name — derived from the PROVIDERS registry. */


### PR DESCRIPTION
## Summary

Adds Evolink as a first-class LLM provider using the existing OpenAI-compatible provider abstraction.

- `LLM_PROVIDER=evolink`
- `EVOLINK_API_KEY` for authentication
- `EVOLINK_MODEL` override, defaulting to `gpt-5.2`
- Base URL: `https://direct.evolink.ai/v1`

Also updates the provider registry, provider unit tests, `.env.example`, and English/Chinese setup docs.

## Validation

- `pnpm format:check` → passed (`All matched files use Prettier code style!`)
- `pnpm vitest run src/__tests__/providers.test.ts` → passed (`1 passed`, `38 passed`)
- `pnpm lint` → passed
- `pnpm typecheck` → passed
- `pnpm test` → passed (`12 passed`, `202 passed`)
- Pre-commit hook during commit → passed (`pnpm lint`, `pnpm format:check`, `pnpm typecheck`)

Real Evolink compatibility checks:

```bash
env -u all_proxy -u http_proxy -u https_proxy -u ALL_PROXY -u HTTP_PROXY -u HTTPS_PROXY \
  curl -sS -w '\nHTTP_STATUS:%{http_code}\n' \
  -X POST https://direct.evolink.ai/v1/chat/completions \
  -H "Authorization: Bearer $EVOLINK_API_KEY" \
  -H "Content-Type: application/json" \
  -d '{"model":"gpt-5.2","messages":[{"role":"user","content":"Reply with exactly: evolink ok"}],"max_completion_tokens":16}'
```

Result: `HTTP_STATUS:200`, assistant content `evolink ok`, returned model `gpt-5.2-2025-12-11`.

```bash
env -u all_proxy -u http_proxy -u https_proxy -u ALL_PROXY -u HTTP_PROXY -u HTTPS_PROXY \
  pnpm tsx -e "import { createProvider } from './src/providers/index.ts'; void (async () => { const provider = createProvider('evolink'); const text = await provider.call('Reply with exactly: provider ok', 16); console.log(text); })();"
```

Result:

```text
[providers] Using LLM provider: evolink
provider ok
```
