### PR TITLE
Use HN topstories for AI digest

### DIFF
--- a/src/__tests__/hn.test.ts
+++ b/src/__tests__/hn.test.ts
@@ -1,0 +1,98 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { fetchHnData } from "../hn.ts";
+
+function jsonResponse(data: unknown, status = 200): Response {
+  return new Response(JSON.stringify(data), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+describe("fetchHnData", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("preserves Hacker News rank order after filtering AI stories", async () => {
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (input) => {
+      const url = String(input);
+
+      if (url.endsWith("/topstories.json")) {
+        return jsonResponse([101, 102, 103, 104]);
+      }
+
+      const id = Number(url.match(/item\/(\d+)\.json$/)?.[1]);
+      const items = new Map<number, unknown>([
+        [
+          101,
+          {
+            id: 101,
+            type: "story",
+            by: "alice",
+            time: 1_800_000_000,
+            title: "Open hardware router",
+            score: 500,
+            descendants: 20,
+            url: "https://example.com/router",
+          },
+        ],
+        [
+          102,
+          {
+            id: 102,
+            type: "story",
+            by: "bob",
+            time: 1_800_000_100,
+            title: "A global workspace in language models",
+            score: 100,
+            descendants: 10,
+            url: "https://example.com/language-models",
+          },
+        ],
+        [
+          103,
+          {
+            id: 103,
+            type: "story",
+            by: "carol",
+            time: 1_800_000_200,
+            title: "Office suite for AI agents",
+            score: 300,
+            descendants: 15,
+            url: "https://example.com/ai-agents",
+          },
+        ],
+        [
+          104,
+          {
+            id: 104,
+            type: "story",
+            by: "dave",
+            time: 1_800_000_300,
+            title: "Ask HN: Favorite terminals",
+            score: 400,
+            descendants: 30,
+            url: "https://example.com/terminals",
+          },
+        ],
+      ]);
+
+      return jsonResponse(items.get(id) ?? null);
+    });
+
+    const result = await fetchHnData();
+
+    expect(result.fetchSuccess).toBe(true);
+    expect(result.stories.map((story) => story.id)).toEqual(["102", "103"]);
+    expect(result.stories.map((story) => story.hnRank)).toEqual([2, 3]);
+    expect(result.stories.map((story) => story.points)).toEqual([100, 300]);
+  });
+
+  it("returns an unsuccessful result when the topstories request fails", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(jsonResponse({ error: "failed" }, 500));
+
+    const result = await fetchHnData();
+
+    expect(result).toEqual({ stories: [], fetchSuccess: false });
+  });
+});

--- a/src/hn.ts
+++ b/src/hn.ts
@@ -1,5 +1,5 @@
 /**
- * Hacker News AI stories fetched via the Algolia HN Search API.
+ * Hacker News AI stories fetched from the official Firebase API.
  */
 
 // ---------------------------------------------------------------------------
@@ -8,6 +8,7 @@
 
 export interface HnStory {
   id: string;
+  hnRank?: number;
   title: string;
   url: string; // external URL, or HN discussion link if no external URL
   hnUrl: string; // always the HN discussion link
@@ -27,26 +28,70 @@ export interface HnData {
 // ---------------------------------------------------------------------------
 
 const HN_TOP_STORIES = 30;
+const HN_STORIES_TO_SCAN = 500;
+const HN_BATCH_SIZE = 50;
 
-/** Queries run in parallel; results are deduped by story ID. */
-const QUERIES = ["AI", "LLM", "Claude", "OpenAI", "Anthropic", "machine learning"];
+const HN_TOPSTORIES_URL = "https://hacker-news.firebaseio.com/v0/topstories.json";
+const HN_ITEM_URL = (id: number) => `https://hacker-news.firebaseio.com/v0/item/${id}.json`;
 
 // ---------------------------------------------------------------------------
-// Algolia API types
+// Firebase API types
 // ---------------------------------------------------------------------------
 
-interface AlgoliaHit {
-  objectID: string;
-  title: string;
+interface HnFirebaseItem {
+  id: number;
+  deleted?: boolean;
+  dead?: boolean;
+  type?: string;
+  by?: string;
+  time?: number;
+  title?: string;
   url?: string;
-  points: number;
-  num_comments: number;
-  author: string;
-  created_at: string;
+  score?: number;
+  descendants?: number;
 }
 
-interface AlgoliaResponse {
-  hits: AlgoliaHit[];
+const AI_KEYWORD_PATTERNS = [
+  /\bai\b/i,
+  /\ba\.i\./i,
+  /\bllm(s)?\b/i,
+  /\bml\b/i,
+  /machine learning/i,
+  /deep learning/i,
+  /neural/i,
+  /transformer/i,
+  /language model(s)?\b/i,
+  /foundation model(s)?\b/i,
+  /\brag\b/i,
+  /agent(s)?\b/i,
+  /openai/i,
+  /anthropic/i,
+  /claude/i,
+  /chatgpt/i,
+  /gemini/i,
+  /copilot/i,
+];
+
+function isAiRelated(item: HnFirebaseItem): boolean {
+  const text = `${item.title ?? ""} ${item.url ?? ""}`;
+  return AI_KEYWORD_PATTERNS.some((pattern) => pattern.test(text));
+}
+
+function toHnStory(item: HnFirebaseItem, hnRank: number): HnStory {
+  const id = String(item.id);
+  const hnUrl = `https://news.ycombinator.com/item?id=${id}`;
+
+  return {
+    id,
+    hnRank,
+    title: item.title ?? "(untitled)",
+    url: item.url ?? hnUrl,
+    hnUrl,
+    points: item.score ?? 0,
+    comments: item.descendants ?? 0,
+    author: item.by ?? "unknown",
+    createdAt: item.time ? new Date(item.time * 1000).toISOString() : new Date(0).toISOString(),
+  };
 }
 
 // ---------------------------------------------------------------------------
@@ -54,51 +99,45 @@ interface AlgoliaResponse {
 // ---------------------------------------------------------------------------
 
 export async function fetchHnData(): Promise<HnData> {
-  const since = Math.floor((Date.now() - 24 * 60 * 60 * 1000) / 1000);
-  const seen = new Map<string, HnStory>();
-
   try {
-    await Promise.all(
-      QUERIES.map(async (q) => {
-        try {
-          const url =
-            `https://hn.algolia.com/api/v1/search_by_date` +
-            `?tags=story` +
-            `&query=${encodeURIComponent(q)}` +
-            `&numericFilters=created_at_i>${since}` +
-            `&hitsPerPage=30`;
-          const resp = await fetch(url, {
+    const topResp = await fetch(HN_TOPSTORIES_URL, {
+      headers: { "User-Agent": "agents-radar/1.0" },
+    });
+    if (!topResp.ok) {
+      console.error(`  [hn] topstories: HTTP ${topResp.status}`);
+      return { stories: [], fetchSuccess: false };
+    }
+
+    const topIds = ((await topResp.json()) as number[]).slice(0, HN_STORIES_TO_SCAN);
+    const stories: HnStory[] = [];
+
+    for (let i = 0; i < topIds.length && stories.length < HN_TOP_STORIES; i += HN_BATCH_SIZE) {
+      const batchIds = topIds.slice(i, i + HN_BATCH_SIZE);
+      const items = await Promise.all(
+        batchIds.map(async (id): Promise<HnFirebaseItem | null> => {
+          const resp = await fetch(HN_ITEM_URL(id), {
             headers: { "User-Agent": "agents-radar/1.0" },
           });
           if (!resp.ok) {
-            console.error(`  [hn] "${q}": HTTP ${resp.status}`);
-            return;
+            console.error(`  [hn] item ${id}: HTTP ${resp.status}`);
+            return null;
           }
-          const data = (await resp.json()) as AlgoliaResponse;
-          for (const hit of data.hits ?? []) {
-            if (!seen.has(hit.objectID)) {
-              const hnUrl = `https://news.ycombinator.com/item?id=${hit.objectID}`;
-              seen.set(hit.objectID, {
-                id: hit.objectID,
-                title: hit.title,
-                url: hit.url ?? hnUrl,
-                hnUrl,
-                points: hit.points ?? 0,
-                comments: hit.num_comments ?? 0,
-                author: hit.author,
-                createdAt: hit.created_at,
-              });
-            }
-          }
-        } catch (err) {
-          console.error(`  [hn] "${q}": ${err}`);
+          return (await resp.json()) as HnFirebaseItem;
+        }),
+      );
+
+      for (let j = 0; j < items.length && stories.length < HN_TOP_STORIES; j += 1) {
+        const item = items[j];
+        if (!item || item.deleted || item.dead || item.type !== "story" || !item.title) {
+          continue;
         }
-      }),
-    );
+        if (isAiRelated(item)) {
+          stories.push(toHnStory(item, i + j + 1));
+        }
+      }
+    }
 
-    const stories = [...seen.values()].sort((a, b) => b.points - a.points).slice(0, HN_TOP_STORIES);
-
-    console.log(`  [hn] ${stories.length} stories (from ${seen.size} unique)`);
+    console.log(`  [hn] ${stories.length} AI stories (scanned ${topIds.length} topstories)`);
     return { stories, fetchSuccess: stories.length > 0 };
   } catch (err) {
     console.error(`  [hn] fetch failed: ${err}`);

--- a/src/prompts-data.ts
+++ b/src/prompts-data.ts
@@ -438,16 +438,16 @@ export function buildHnPrompt(data: HnData, dateStr: string, lang: Lang = "zh"):
         ? `${i + 1}. **${s.title}**\n` +
           `   Link: ${s.url}\n` +
           `   Discussion: ${s.hnUrl}\n` +
-          `   Score: ${s.points} | Comments: ${s.comments} | Author: ${s.author} | Time: ${s.createdAt.slice(0, 16)}`
+          `   HN Rank: ${s.hnRank ?? i + 1} | Score: ${s.points} | Comments: ${s.comments} | Author: ${s.author} | Time: ${s.createdAt.slice(0, 16)}`
         : `${i + 1}. **${s.title}**\n` +
           `   链接: ${s.url}\n` +
           `   讨论: ${s.hnUrl}\n` +
-          `   分数: ${s.points} | 评论: ${s.comments} | 作者: ${s.author} | 时间: ${s.createdAt.slice(0, 16)}`,
+          `   HN 排名: ${s.hnRank ?? i + 1} | 分数: ${s.points} | 评论: ${s.comments} | 作者: ${s.author} | 时间: ${s.createdAt.slice(0, 16)}`,
     )
     .join("\n\n");
 
   if (lang === "en") {
-    return `You are an AI industry news analyst. The following are AI-related top posts from Hacker News in the past 24 hours as of ${dateStr} (sorted by score, ${data.stories.length} total):
+    return `You are an AI industry news analyst. The following are AI-related posts from the current Hacker News topstories feed as of ${dateStr} (ordered by HN rank, ${data.stories.length} total):
 
 ---
 
@@ -481,7 +481,7 @@ Style: English, concise and professional, preserve all original links.
 `;
   }
 
-  return `你是 AI 行业资讯分析师。以下是 ${dateStr} 从 Hacker News 抓取的过去 24 小时内 AI 相关热门帖子（按分数降序，共 ${data.stories.length} 条）：
+  return `你是 AI 行业资讯分析师。以下是 ${dateStr} 从 Hacker News topstories 抓取的 AI 相关热门帖子（按 HN 排名顺序，共 ${data.stories.length} 条）：
 
 ---
 


### PR DESCRIPTION
## Summary
- Fetch Hacker News AI digest candidates from the official Firebase topstories feed instead of Algolia search_by_date.
- Preserve HN front-page rank order and include HN Rank in the digest prompt metadata.
- Add tests covering rank preservation and topstories fetch failure handling.

## Validation
- pnpm format:check
- pnpm typecheck
- pnpm lint
- pnpm exec vitest run src/__tests__/hn.test.ts

## Live smoke test
The new fetcher returned 30 AI-related stories from the current top 500 HN topstories while preserving HN ranks.