### PR TITLE
Track closed-source AI coding tools in ai-cli.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -92,7 +92,7 @@ Files written to `digests/YYYY-MM-DD/`:
 
 ## Tracked sources
 
-- **CLI_REPOS** (9): claude-code, codex, gemini-cli, copilot-cli, kimi-cli, opencode, pi, qwen-code, deepseek-tui
+- **CLI_REPOS** (10): claude-code, codex, gemini-cli, copilot-cli, kimi-cli, opencode, pi, qwen-code, deepseek-tui, grok-cli
 - **OPENCLAW** + **OPENCLAW_PEERS** (13): openclaw/openclaw + 12 peer projects (sorted by stars)
 - **CLAUDE_SKILLS_REPO**: anthropics/skills — no date filter, sorted by popularity
 - **Web**: anthropic.com + openai.com via sitemap, state in `digests/web-state.json`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,7 +44,7 @@ export ANTHROPIC_API_KEY=sk-ant-xxxxx
 
 The pipeline runs in four sequential phases, each implemented as a named async function in `src/index.ts`:
 
-1. **`fetchAllData`** — all network I/O in parallel: GitHub API (issues/PRs/releases) for 17 repos, Claude Code Skills, Anthropic/OpenAI sitemaps, GitHub Trending HTML + Search API, Hacker News Algolia API.
+1. **`fetchAllData`** — all network I/O in parallel: GitHub API (issues/PRs/releases) for 17 repos, Claude Code Skills, Anthropic/OpenAI sitemaps, GitHub Trending HTML + Search API, Hacker News Algolia API, npm registry (closed-source tool versions).
 2. **`generateSummaries`** — per-repo LLM calls, all in parallel, rate-limited to 5 concurrent requests by a queue in `src/report.ts`.
 3. **Comparisons** — two LLM calls: cross-tool CLI comparison and OpenClaw cross-ecosystem comparison.
 4. **Save phase** — `buildCliReportContent` / `buildOpenclawReportContent` (in `src/report-builders.ts`) build Markdown strings; `saveWebReport` / `saveTrendingReport` / `saveHnReport` (in `src/report-savers.ts`) call LLM + write file + create GitHub Issue.
@@ -74,6 +74,8 @@ The pipeline runs in four sequential phases, each implemented as a named async f
 | `src/web.ts` | Sitemap-based web content fetching; state persisted to `digests/web-state.json` |
 | `src/trending.ts` | GitHub Trending HTML scraper + Search API topic queries |
 | `src/hn.ts` | Hacker News top AI stories via Algolia HN Search API |
+| `src/npm.ts` | Closed-source AI coding tools tracked via npm registry (`CLOSED_TOOLS`); owns shared `ClosedTool`/`ClosedToolRelease` types; version-only, no LLM |
+| `src/zcode.ts` | Zhipu ZCode tracked by scraping its HTML changelog (`parseZcodeChangelog`); produces a `ClosedToolRelease` |
 | `src/generate-manifest.ts` | Generates `manifest.json` (sidebar data for Web UI) and `feed.xml` (RSS 2.0 feed) |
 
 ## Report outputs
@@ -96,6 +98,10 @@ Files written to `digests/YYYY-MM-DD/`:
 - **Web**: anthropic.com + openai.com via sitemap, state in `digests/web-state.json`
 - **Trending**: github.com/trending (HTML) + GitHub Search API (6 AI topics, 7-day window)
 - **HN**: Algolia HN Search API — 6 parallel queries, top-30 AI stories by points, last 24h
+- **Closed-source tools** (3, no public repo; each maps to a mainstream model vendor):
+  - **npm-tracked** (`CLOSED_TOOLS` in `src/npm.ts`, 2): minimax-code (`mmx-cli`), codebuddy (`@tencent-ai/codebuddy-code`) — latest version + publish time from the npm registry. Only add tools with a clean, **verified** npm package; do NOT add open-source CLIs (e.g. `@qwen-code/qwen-code` is the open-source Qwen Code, already in CLI_REPOS) and do NOT guess package names.
+  - **changelog-scraped** (`src/zcode.ts`, 1): Zhipu ZCode (`zcode.z.ai/en/changelog`) — server-rendered HTML, latest version + release date parsed by `parseZcodeChangelog`. More fragile than npm; on a page-structure change it reports `fetchSuccess: false` (shown as "fetch failed") without affecting other rows.
+  - All merged into one `ClosedToolRelease[]` in `fetchAllData` and rendered as a version-only table (no LLM) appended to `ai-cli.md` — no separate report. Cursor/Trae are intentionally excluded: no clean public version endpoint (Cursor is version-only via `api2.cursor.sh` with no date; Trae has no npm/PyPI/GitHub release/app-update endpoint).
 
 ## Key conventions
 

--- a/config.yml
+++ b/config.yml
@@ -35,6 +35,9 @@ cli_repos:
   - id: deepseek-tui
     repo: Hmbown/DeepSeek-TUI
     name: DeepSeek TUI
+  - id: grok-cli
+    repo: superagent-ai/grok-cli
+    name: Grok CLI
 
 # ── Claude Code Skills ────────────────────────────────────────────────────────
 # Tracked separately without a date filter, sorted by community engagement.

--- a/src/__tests__/report-builders.test.ts
+++ b/src/__tests__/report-builders.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from "vitest";
 import { buildCliReportContent, buildOpenclawReportContent } from "../report-builders.ts";
 import type { RepoDigest } from "../prompts.ts";
 import type { GitHubItem, GitHubRelease } from "../github.ts";
+import type { ClosedToolRelease } from "../npm.ts";
 
 // ---------------------------------------------------------------------------
 // Fixtures
@@ -36,6 +37,7 @@ describe("buildCliReportContent", () => {
       "2026-03-09",
       "\n---\nfooter",
       "anthropics/skills",
+      [],
       "zh",
     );
 
@@ -59,6 +61,7 @@ describe("buildCliReportContent", () => {
       "2026-03-09",
       "",
       "anthropics/skills",
+      [],
       "en",
     );
     expect(result).toContain("# AI CLI Tools Community Digest 2026-03-09");
@@ -78,6 +81,7 @@ describe("buildCliReportContent", () => {
       "",
       "",
       "anthropics/skills",
+      [],
       "zh",
     );
 
@@ -87,6 +91,57 @@ describe("buildCliReportContent", () => {
     expect(skillsIdx).toBeGreaterThan(claudeIdx);
     // Skills should not appear after codex section
     expect(result.split("SKILLS_CONTENT")).toHaveLength(2); // appears exactly once
+  });
+
+  it("renders closed-source tools as a table with new releases sorted first", () => {
+    const closed: ClosedToolRelease[] = [
+      {
+        tool: {
+          id: "amp",
+          name: "Amp",
+          vendor: { zh: "Sourcegraph", en: "Sourcegraph" },
+          model: "Claude / GPT",
+        },
+        latestVersion: "0.1.0",
+        latestPublishedAt: "2026-03-01T00:00:00.000Z",
+        isNew: false, // latest is weeks old
+        fetchSuccess: true,
+      },
+      {
+        tool: {
+          id: "codebuddy",
+          name: "CodeBuddy",
+          vendor: { zh: "腾讯", en: "Tencent" },
+          model: "Hunyuan 混元",
+        },
+        latestVersion: "2.122.0",
+        latestPublishedAt: "2026-03-09T14:00:00.000Z",
+        isNew: true, // shipped in window
+        fetchSuccess: true,
+      },
+    ];
+    const result = buildCliReportContent(
+      [makeDigest()],
+      "Skills",
+      "Comparison",
+      "2026-03-09 00:00",
+      "2026-03-09",
+      "",
+      "anthropics/skills",
+      closed,
+      "zh",
+    );
+
+    expect(result).toContain("闭源工具追踪");
+    expect(result).toContain("| CodeBuddy | 腾讯 · Hunyuan 混元 | `2.122.0` | 2026-03-09 | 🆕 今日更新 |");
+    expect(result).toContain("| Amp | Sourcegraph · Claude / GPT | `0.1.0` | 2026-03-01 | — |");
+    // New release (CodeBuddy) sorts above the tool with no new release (Amp)
+    expect(result.indexOf("CodeBuddy |")).toBeLessThan(result.indexOf("Amp |"));
+  });
+
+  it("omits the closed-source section when no tools are tracked", () => {
+    const result = buildCliReportContent([makeDigest()], "", "", "", "", "", "anthropics/skills", [], "zh");
+    expect(result).not.toContain("闭源工具追踪");
   });
 });
 

--- a/src/__tests__/zcode.test.ts
+++ b/src/__tests__/zcode.test.ts
@@ -1,0 +1,25 @@
+import { describe, it, expect } from "vitest";
+import { parseZcodeChangelog } from "../zcode.ts";
+
+// Mirrors the real page: <span>version</span><span>Released Mon D, YYYY</span>,
+// with a script tag and an earlier prose "version" that must not be matched.
+const HTML = `<!DOCTYPE html><html><head><script>var x="9.9.9 Released Jan 1, 2000"</script></head>
+<body><h1>Releases &amp; Updates</h1><p>Release notes for every ZCode version.</p>
+<div><span class="font-mono">3.3.6</span><span>Released Jul 15, 2026</span></div>
+<div>Bug Fixes: stuff</div>
+<div><span class="font-mono">3.3.5</span><span>Released Jul 13, 2026</span></div>
+</body></html>`;
+
+describe("parseZcodeChangelog", () => {
+  it("extracts the first (latest) version and date, ignoring script noise", () => {
+    const r = parseZcodeChangelog(HTML);
+    expect(r).not.toBeNull();
+    expect(r!.version).toBe("3.3.6");
+    // Jul 15, 2026 → UTC midnight ISO
+    expect(r!.publishedAt).toBe("2026-07-15T00:00:00.000Z");
+  });
+
+  it("returns null when no entry matches (structure changed)", () => {
+    expect(parseZcodeChangelog("<html><body>No releases here</body></html>")).toBeNull();
+  });
+});

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -38,6 +38,20 @@ export const CLI_REPORT = {
   skillsSource: t("数据来源", "Source"),
   comparison: t("横向对比", "Cross-Tool Comparison"),
   detail: t("各工具详细报告", "Per-Tool Reports"),
+  closed: {
+    heading: t("闭源工具追踪", "Closed-Source Tools"),
+    note: t(
+      "仅版本追踪（数据来源: npm registry / 官方 changelog）。这些工具无公开仓库，每个对应一家主流模型厂商。",
+      "Version tracking only (source: npm registry / official changelog). No public repo; each maps to a mainstream model vendor.",
+    ),
+    colTool: t("工具", "Tool"),
+    colVendor: t("厂商 / 模型", "Vendor / Model"),
+    colVersion: t("最新版本", "Latest"),
+    colPublished: t("发布时间", "Published"),
+    colStatus: t("状态", "Status"),
+    statusNew: t("🆕 今日更新", "🆕 New"),
+    statusFail: t("查询失败", "fetch failed"),
+  },
 } as const;
 
 export const OPENCLAW_REPORT = {

--- a/src/index.ts
+++ b/src/index.ts
@@ -47,6 +47,8 @@ import { fetchArxivData, type ArxivData } from "./arxiv.ts";
 import { fetchHfData, type HfData } from "./hf.ts";
 import { fetchDevtoData, type DevtoData } from "./devto.ts";
 import { fetchLobstersData, type LobstersData } from "./lobsters.ts";
+import { fetchNpmData, type ClosedToolRelease } from "./npm.ts";
+import { fetchZcodeRelease } from "./zcode.ts";
 import { loadConfig } from "./config.ts";
 import { toCstDateStr, toUtcStr } from "./date.ts";
 import { type Lang, MSG, ISSUE_LABELS, CLI_ISSUE_TITLE, OPENCLAW_ISSUE_TITLE } from "./i18n.ts";
@@ -90,6 +92,7 @@ async function fetchAllData(
   hfData: HfData;
   devtoData: DevtoData;
   lobstersData: LobstersData;
+  closedReleases: ClosedToolRelease[];
 }> {
   const allConfigs = [...CLI_REPOS, OPENCLAW, ...OPENCLAW_PEERS];
   console.log(
@@ -107,6 +110,7 @@ async function fetchAllData(
     hfData,
     devtoData,
     lobstersData,
+    closedReleases,
   ] = await Promise.all([
     Promise.all(
       allConfigs.map(async (cfg) => {
@@ -165,6 +169,12 @@ async function fetchAllData(
     fetchHfData().catch((): HfData => ({ models: [], fetchSuccess: false })),
     fetchDevtoData().catch((): DevtoData => ({ articles: [], fetchSuccess: false })),
     fetchLobstersData().catch((): LobstersData => ({ stories: [], fetchSuccess: false })),
+    // Closed-source tools: npm-tracked (version + date) plus ZCode's HTML
+    // changelog. Each source already falls back safely on error.
+    Promise.all([fetchNpmData(since), fetchZcodeRelease(since)]).then(([npm, zcode]) => [
+      ...npm.releases,
+      zcode,
+    ]),
   ]);
 
   return {
@@ -178,6 +188,7 @@ async function fetchAllData(
     hfData,
     devtoData,
     lobstersData,
+    closedReleases,
   };
 }
 
@@ -311,6 +322,7 @@ async function main(): Promise<void> {
     hfData,
     devtoData,
     lobstersData,
+    closedReleases,
   } = await fetchAllData(since, webState);
 
   const peerIds = new Set(OPENCLAW_PEERS.map((p) => p.id));
@@ -364,6 +376,7 @@ async function main(): Promise<void> {
       dateStr,
       ft,
       CLAUDE_SKILLS_REPO,
+      closedReleases,
       lang,
     );
     openclawContent[lang] = buildOpenclawReportContent(

--- a/src/npm.ts
+++ b/src/npm.ts
@@ -1,0 +1,103 @@
+/**
+ * Closed-source AI coding tools tracked via the npm registry.
+ *
+ * These tools have no public GitHub repo, but ship a CLI on npm. The registry
+ * exposes clean version + publish-time data, which is the highest-signal way to
+ * detect that a closed tool shipped a new release. Each tool maps to a
+ * mainstream model vendor — it is that lab's productization arm.
+ */
+
+import type { Lang } from "./i18n.ts";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/** Display metadata shared by every closed-source tool, regardless of source. */
+export interface ClosedTool {
+  id: string;
+  name: string;
+  vendor: Record<Lang, string>;
+  model: string; // flagship model the tool is a productization arm of
+}
+
+/** A closed tool whose releases are tracked via the npm registry. */
+interface NpmTool extends ClosedTool {
+  npmPkg: string;
+}
+
+export interface ClosedToolRelease {
+  tool: ClosedTool;
+  latestVersion: string | null;
+  latestPublishedAt: string | null; // ISO timestamp of the latest version
+  isNew: boolean; // latest version was published within the digest window
+  fetchSuccess: boolean;
+}
+
+export interface NpmData {
+  releases: ClosedToolRelease[];
+}
+
+// ---------------------------------------------------------------------------
+// Tracked tools — closed-source coding tools that ship a CLI on npm.
+// Do NOT add open-source CLIs here (they belong in CLI_REPOS); e.g.
+// @qwen-code/qwen-code is the open-source Qwen Code, not the closed Qoder IDE.
+// ---------------------------------------------------------------------------
+
+export const CLOSED_TOOLS: NpmTool[] = [
+  {
+    id: "minimax-code",
+    name: "MiniMax Code",
+    vendor: { zh: "MiniMax", en: "MiniMax" },
+    model: "MiniMax M1",
+    npmPkg: "mmx-cli",
+  },
+  {
+    id: "codebuddy",
+    name: "CodeBuddy",
+    vendor: { zh: "腾讯", en: "Tencent" },
+    model: "Hunyuan 混元",
+    npmPkg: "@tencent-ai/codebuddy-code",
+  },
+];
+
+// ---------------------------------------------------------------------------
+// Fetch
+// ---------------------------------------------------------------------------
+
+const REGISTRY = "https://registry.npmjs.org";
+
+/** Full registry doc — the abbreviated `install-v1` format omits `time`. */
+interface NpmRegistryDoc {
+  "dist-tags"?: { latest?: string };
+  time?: Record<string, string>;
+}
+
+async function fetchOne(tool: NpmTool, since: Date): Promise<ClosedToolRelease> {
+  try {
+    const resp = await fetch(`${REGISTRY}/${encodeURIComponent(tool.npmPkg)}`);
+    if (!resp.ok) throw new Error(`HTTP ${resp.status}`);
+    const data = (await resp.json()) as NpmRegistryDoc;
+
+    const latestVersion = data["dist-tags"]?.latest ?? null;
+    const time = data.time ?? {};
+    const latestPublishedAt = latestVersion ? (time[latestVersion] ?? null) : null;
+
+    // Flag "new" off the published dist-tag `latest` only — matching the
+    // Published column exactly. Counting all `time` entries would let a daily
+    // prerelease churn (e.g. Augment's -prerelease.N) mark every tool new while
+    // the shown stable version is weeks old.
+    const isNew = latestPublishedAt !== null && new Date(latestPublishedAt).getTime() >= since.getTime();
+
+    console.log(`  [npm/${tool.id}] latest: ${latestVersion ?? "?"}, new: ${isNew}`);
+    return { tool, latestVersion, latestPublishedAt, isNew, fetchSuccess: true };
+  } catch (err) {
+    console.error(`  [npm/${tool.id}] fetch failed: ${err}`);
+    return { tool, latestVersion: null, latestPublishedAt: null, isNew: false, fetchSuccess: false };
+  }
+}
+
+export async function fetchNpmData(since: Date): Promise<NpmData> {
+  const releases = await Promise.all(CLOSED_TOOLS.map((t) => fetchOne(t, since)));
+  return { releases };
+}

--- a/src/report-builders.ts
+++ b/src/report-builders.ts
@@ -4,7 +4,35 @@
 
 import type { RepoConfig, RepoFetch } from "./github.ts";
 import type { RepoDigest } from "./prompts.ts";
+import type { ClosedToolRelease } from "./npm.ts";
 import { type Lang, CLI_REPORT, OPENCLAW_REPORT } from "./i18n.ts";
+
+// ---------------------------------------------------------------------------
+// Closed-source tools section — a version-only table (no LLM summary).
+// New releases (published within the digest window) are sorted to the top.
+// ---------------------------------------------------------------------------
+
+function buildClosedSection(releases: ClosedToolRelease[], lang: Lang): string {
+  if (releases.length === 0) return "";
+
+  const c = CLI_REPORT.closed;
+  const head =
+    `| ${c.colTool[lang]} | ${c.colVendor[lang]} | ${c.colVersion[lang]} | ${c.colPublished[lang]} | ${c.colStatus[lang]} |\n` +
+    `| --- | --- | --- | --- | --- |`;
+
+  const rows = [...releases]
+    .sort((a, b) => Number(b.isNew) - Number(a.isNew))
+    .map((r) => {
+      const vendorModel = `${r.tool.vendor[lang]} · ${r.tool.model}`;
+      const version = r.latestVersion ? `\`${r.latestVersion}\`` : "—";
+      const published = r.latestPublishedAt ? r.latestPublishedAt.slice(0, 10) : "—";
+      const status = !r.fetchSuccess ? c.statusFail[lang] : r.isNew ? c.statusNew[lang] : "—";
+      return `| ${r.tool.name} | ${vendorModel} | ${version} | ${published} | ${status} |`;
+    })
+    .join("\n");
+
+  return `\n\n---\n\n## ${c.heading[lang]}\n\n> ${c.note[lang]}\n\n${head}\n${rows}\n`;
+}
 
 // ---------------------------------------------------------------------------
 // CLI Report
@@ -18,6 +46,7 @@ export function buildCliReportContent(
   dateStr: string,
   footer: string,
   skillsRepo: string,
+  closedReleases: ClosedToolRelease[] = [],
   lang: Lang = "zh",
 ): string {
   const repoLinks =
@@ -56,6 +85,7 @@ export function buildCliReportContent(
     `\n\n---\n\n` +
     `## ${CLI_REPORT.detail[lang]}\n\n` +
     toolSections +
+    buildClosedSection(closedReleases, lang) +
     footer
   );
 }

--- a/src/zcode.ts
+++ b/src/zcode.ts
@@ -1,0 +1,86 @@
+/**
+ * Zhipu (Z.ai) ZCode — closed-source AI coding IDE tracked via its public HTML
+ * changelog (no npm package). The changelog is server-rendered, so the latest
+ * version + release date can be scraped from the initial HTML. This is more
+ * fragile than the npm registry: a page-structure change breaks parsing, in
+ * which case the tool is reported with `fetchSuccess: false` (marked "fetch
+ * failed" in the table) without affecting the npm-tracked rows.
+ */
+
+import type { ClosedTool, ClosedToolRelease } from "./npm.ts";
+
+const ZCODE_CHANGELOG_URL = "https://zcode.z.ai/en/changelog";
+
+export const ZCODE_TOOL: ClosedTool = {
+  id: "zcode",
+  name: "ZCode",
+  vendor: { zh: "智谱", en: "Zhipu" },
+  model: "GLM",
+};
+
+const MONTHS: Record<string, number> = {
+  Jan: 0,
+  Feb: 1,
+  Mar: 2,
+  Apr: 3,
+  May: 4,
+  Jun: 5,
+  Jul: 6,
+  Aug: 7,
+  Sep: 8,
+  Oct: 9,
+  Nov: 10,
+  Dec: 11,
+};
+
+/**
+ * Extract the latest version + release date from the ZCode changelog HTML.
+ * Entries render as `<span>3.3.6</span><span>Released Jul 15, 2026</span>`, so
+ * after stripping tags the first `<x.y.z> Released <Mon D, YYYY>` wins.
+ * Returns null if the structure changed and nothing matched.
+ */
+export function parseZcodeChangelog(html: string): { version: string; publishedAt: string } | null {
+  const text = html
+    .replace(/<(script|style)[^>]*>[\s\S]*?<\/\1>/gi, "")
+    .replace(/<[^>]+>/g, " ")
+    .replace(/\s+/g, " ");
+  const m = text.match(/(\d+\.\d+\.\d+)\s+Released\s+([A-Z][a-z]{2})\s+(\d{1,2}),\s+(\d{4})/);
+  if (!m) return null;
+
+  const [, version, mon, day, year] = m;
+  const month = mon ? MONTHS[mon] : undefined;
+  if (!version || !day || !year || month === undefined) return null;
+
+  const publishedAt = new Date(Date.UTC(Number(year), month, Number(day))).toISOString();
+  return { version, publishedAt };
+}
+
+export async function fetchZcodeRelease(since: Date): Promise<ClosedToolRelease> {
+  try {
+    const resp = await fetch(ZCODE_CHANGELOG_URL, {
+      headers: { "User-Agent": "Mozilla/5.0 (agents-radar)" },
+    });
+    if (!resp.ok) throw new Error(`HTTP ${resp.status}`);
+    const parsed = parseZcodeChangelog(await resp.text());
+    if (!parsed) throw new Error("changelog structure not recognized");
+
+    const isNew = new Date(parsed.publishedAt).getTime() >= since.getTime();
+    console.log(`  [zcode] latest: ${parsed.version}, new: ${isNew}`);
+    return {
+      tool: ZCODE_TOOL,
+      latestVersion: parsed.version,
+      latestPublishedAt: parsed.publishedAt,
+      isNew,
+      fetchSuccess: true,
+    };
+  } catch (err) {
+    console.error(`  [zcode] fetch failed: ${err}`);
+    return {
+      tool: ZCODE_TOOL,
+      latestVersion: null,
+      latestPublishedAt: null,
+      isNew: false,
+      fetchSuccess: false,
+    };
+  }
+}


### PR DESCRIPTION
Add a version-only "closed-source tools" table appended to the CLI report, tracking tools that have no public GitHub repo. Each maps to a mainstream model vendor.

Signals (mixed, verified against live endpoints):
- npm registry (mmx-cli, @tencent-ai/codebuddy-code) — version + date
- HTML changelog scrape (Zhipu ZCode) — version + release date

ClosedTool is split into shared display metadata plus source-specific subtypes so new signal sources reuse the same table. ZCode scraping fails gracefully (fetchSuccess: false) without affecting npm rows. Cursor/Trae are intentionally excluded: no clean public version endpoint.