### PR TITLE
feat: track Tura as an open-source coding agent CLI

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -92,7 +92,7 @@ Files written to `digests/YYYY-MM-DD/`:
 
 ## Tracked sources
 
-- **CLI_REPOS** (10): claude-code, codex, gemini-cli, copilot-cli, kimi-cli, opencode, pi, qwen-code, deepseek-tui, grok-cli
+- **CLI_REPOS** (11): claude-code, codex, gemini-cli, copilot-cli, kimi-cli, opencode, pi, qwen-code, deepseek-tui, grok-cli, tura
 - **OPENCLAW** + **OPENCLAW_PEERS** (13): openclaw/openclaw + 12 peer projects (sorted by stars)
 - **CLAUDE_SKILLS_REPO**: anthropics/skills — no date filter, sorted by popularity
 - **Web**: anthropic.com + openai.com via sitemap, state in `digests/web-state.json`

--- a/config.yml
+++ b/config.yml
@@ -38,6 +38,9 @@ cli_repos:
   - id: grok-cli
     repo: superagent-ai/grok-cli
     name: Grok CLI
+  - id: tura
+    repo: Tura-AI/tura
+    name: Tura
 
 # ── Claude Code Skills ────────────────────────────────────────────────────────
 # Tracked separately without a date filter, sorted by community engagement.


### PR DESCRIPTION
## Summary

- add `Tura-AI/tura` to the configurable `cli_repos` registry
- update the tracked CLI source count in `CLAUDE.md`

## Why

Tura is a local, open-source coding agent with an interactive terminal UI and a Rust CLI. It fits the same per-tool digest and cross-tool comparison pipeline as the existing Codex, Claude Code, Gemini CLI, OpenCode, and Grok CLI entries.

Project: https://github.com/Tura-AI/tura
Website: https://turaai.net/

## Validation

- parsed `config.yml` successfully and verified the exact Tura entry
- `git diff --check` passes

## Disclosure

I am affiliated with the Tura project. This submission was prepared with AI assistance and manually reviewed before opening.