### PR TITLE
Update DeepSeek default model to deepseek-v4-flash

### DIFF
--- a/src/providers/deepseek.ts
+++ b/src/providers/deepseek.ts
@@ -3,7 +3,7 @@
  *
  * Env vars:
  *   DEEPSEEK_API_KEY  - API key
- *   DEEPSEEK_MODEL    - model name (default: deepseek-chat)
+ *   DEEPSEEK_MODEL    - model name (default: deepseek-v4-flash)
  */
 
 import { OpenAICompatibleProvider } from "./openai-compatible.ts";
@@ -17,7 +17,7 @@ export class DeepSeekProvider extends OpenAICompatibleProvider {
     super({
       apiKey: opts?.apiKey ?? process.env["DEEPSEEK_API_KEY"],
       baseURL: DEEPSEEK_BASE_URL,
-      model: opts?.model ?? process.env["DEEPSEEK_MODEL"] ?? "deepseek-chat",
+      model: opts?.model ?? process.env["DEEPSEEK_MODEL"] ?? "deepseek-v4-flash",
     });
   }
 }


### PR DESCRIPTION
DeepSeek deprecated the deepseek-chat model name; the API now only accepts deepseek-v4-pro or deepseek-v4-flash. This caused all LLM calls in the daily digest to fail with a 400 invalid_request_error.