### PR TITLE
docs: add Grok Build to tracked AI CLI tools table in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ wrangler deploy
 | Pi | [badlogic/pi-mono](https://github.com/badlogic/pi-mono) |
 | Qwen Code | [QwenLM/qwen-code](https://github.com/QwenLM/qwen-code) |
 | DeepSeek TUI | [Hmbown/DeepSeek-TUI](https://github.com/Hmbown/DeepSeek-TUI) |
+| Grok Build | [xai-org/grok-build](https://github.com/xai-org/grok-build) |
 
 ### Claude Code Skills (GitHub)
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -126,6 +126,7 @@ wrangler deploy
 | OpenCode | [anomalyco/opencode](https://github.com/anomalyco/opencode) |
 | Qwen Code | [QwenLM/qwen-code](https://github.com/QwenLM/qwen-code) |
 | DeepSeek TUI | [Hmbown/DeepSeek-TUI](https://github.com/Hmbown/DeepSeek-TUI) |
+| Grok Build | [xai-org/grok-build](https://github.com/xai-org/grok-build) |
 
 ### Claude Code Skills（GitHub）
 


### PR DESCRIPTION
## What

Add **Grok Build** (`xai-org/grok-build`) to the "AI CLI tools (GitHub)" table in README.md.

## Why

Grok Build was added to `config.yml` on July 17 (PR #2191) and has been included in daily digests since then, but the README table was not updated — it still shows 9 tools instead of the actual 10 being tracked.

This is a docs-only change to bring the README in sync with `config.yml`.

## Change

```diff
 | DeepSeek TUI | [Hmbown/DeepSeek-TUI](https://github.com/Hmbown/DeepSeek-TUI) |
+| Grok Build | [xai-org/grok-build](https://github.com/xai-org/grok-build) |
```
