### PR TITLE
feat: add daily Top 5 information radar

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,9 @@
-# LLM provider for local scripts 
+# Choose one LLM provider and set only its required key.
+LLM_PROVIDER=deepseek
+DEEPSEEK_API_KEY=sk-xxxxx
+
+# Alternative providers:
 # LLM_PROVIDER=anthropic
-ANTHROPIC_API_KEY=sk-ant-xxxxx
+# ANTHROPIC_API_KEY=sk-ant-xxxxx
+# LLM_PROVIDER=openai
 # OPENAI_API_KEY=sk-xxxxx

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 node_modules/
 dist/
 social/
+.worktrees/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,38 +16,34 @@ pnpm format         # Prettier --write src
 pnpm format:check   # Prettier --check src
 ```
 
-Required env vars for local runs:
+Preferred Windows local run (DeepSeek):
 
-```bash
-export GITHUB_TOKEN=ghp_xxxxx
-export DIGEST_REPO=owner/repo   # omit to skip GitHub issue creation
-
-# LLM provider (default: anthropic)
-export LLM_PROVIDER=anthropic   # anthropic | openai | github-copilot | openrouter | deepseek
-
-# Anthropic (default)
-export ANTHROPIC_API_KEY=sk-ant-xxxxx
-
-# OpenAI
-# export OPENAI_API_KEY=sk-xxxxx
-
-# GitHub Copilot — uses GITHUB_TOKEN
-
-# OpenRouter
-# export OPENROUTER_API_KEY=sk-or-xxxxx
-
-# DeepSeek
-# export DEEPSEEK_API_KEY=sk-xxxxx
+```dotenv
+LLM_PROVIDER=deepseek
+DEEPSEEK_API_KEY=sk-xxxxx
 ```
+
+Keep only the provider and its required key in the ignored `.env` file. Then run from PowerShell:
+
+```powershell
+corepack pnpm install --frozen-lockfile
+$env:GITHUB_TOKEN = gh auth token
+Remove-Item Env:DIGEST_REPO -ErrorAction SilentlyContinue
+node --env-file=.env --import=tsx src/index.ts
+```
+
+`GITHUB_TOKEN` belongs only to the current process and must not be written to `.env`. With `DIGEST_REPO` unset, reports are written locally and no GitHub Issues are created. Set `DIGEST_REPO=owner/repo` only for an intentional publishing run.
+
+The provider factory still defaults to `anthropic` when `LLM_PROVIDER` is absent. Supported providers are `anthropic`, `openai`, `github-copilot`, `openrouter`, and `deepseek`; their required keys are documented in `.env.example` and `README.md`.
 
 ## Architecture
 
 The pipeline runs in four sequential phases, each implemented as a named async function in `src/index.ts`:
 
-1. **`fetchAllData`** — all network I/O in parallel: GitHub API (issues/PRs/releases) for 17 repos, Claude Code Skills, Anthropic/OpenAI sitemaps, GitHub Trending HTML + Search API, Hacker News Algolia API.
+1. **`fetchAllData`** — all network I/O in parallel: GitHub API (issues/PRs/releases) for 17 repos, Claude Code Skills, Anthropic/OpenAI sitemaps, GitHub Trending HTML + Search API, and Hacker News Firebase Top Stories.
 2. **`generateSummaries`** — per-repo LLM calls, all in parallel, rate-limited to 5 concurrent requests by a queue in `src/report.ts`.
-3. **Comparisons** — two LLM calls: cross-tool CLI comparison and OpenClaw cross-ecosystem comparison.
-4. **Save phase** — `buildCliReportContent` / `buildOpenclawReportContent` / `buildInfraReportContent` (in `src/report-builders.ts`) build Markdown strings; `saveWebReport` / `saveTrendingReport` / `saveHnReport` (in `src/report-savers.ts`) call LLM + write file + create GitHub Issue.
+3. **Comparisons and Radar** — the existing comparison calls plus one bilingual Radar editorial request; Radar falls back to deterministic scoring if that request fails validation or exhausts retries.
+4. **Save phase** — report builders assemble Markdown; savers write bilingual files and create GitHub Issues only when `DIGEST_REPO` is explicitly set. `saveRadarReport` reuses the single shared Radar result for both languages.
 
 ## Source files
 
@@ -58,10 +54,10 @@ The pipeline runs in four sequential phases, each implemented as a named async f
 | `src/github.ts` | GitHub API helpers: `fetchRecentItems`, `fetchRecentReleases`, `fetchSkillsData`, `createGitHubIssue`; shared `RepoFetch` type |
 | `src/config.ts` | Loads `config.yml` into `RadarConfig` (`cliRepos`, `skillsRepo`, `openclaw`, `openclawPeers`, `infraRepos`); built-in defaults when a section is missing |
 | `src/prompts.ts` | LLM prompt builders for repo reports: `buildCliPrompt`, `buildPeerPrompt`, `buildInfraPrompt`, `buildComparisonPrompt`, `buildInfraComparisonPrompt`, `buildPeersComparisonPrompt`, `buildSkillsPrompt` |
-| `src/prompts-data.ts` | LLM prompt builders for data-source reports: `buildTrendingPrompt`, `buildWebReportPrompt`, `buildHnPrompt` |
+| `src/prompts-data.ts` | LLM prompt builders for data-source reports, including one bilingual `buildRadarPrompt` request for all Radar candidates |
 | `src/report.ts` | `callLlm` (with concurrency limiter), `saveFile`, `autoGenFooter` (uses i18n), LLM token budget constants |
-| `src/report-builders.ts` | `buildCliReportContent`, `buildOpenclawReportContent`, `buildInfraReportContent` — assemble final Markdown strings for CLI, OpenClaw and infra reports |
-| `src/report-savers.ts` | `saveWebReport`, `saveTrendingReport`, `saveHnReport` — LLM call + file save + optional GitHub issue |
+| `src/report-builders.ts` | Pure Markdown builders, including `buildRadarReportContent` for bilingual candidate tables and Top 5 sections |
+| `src/report-savers.ts` | Report save wrappers, including `saveRadarReport`; GitHub Issue creation is conditional on `DIGEST_REPO` |
 | `src/date.ts` | Date and timing utilities: `toCstDateStr`, `toUtcStr`, `sleep` |
 | `src/providers/types.ts` | `LlmProvider` interface, `ProviderName` type, `VALID_PROVIDER_NAMES` |
 | `src/providers/openai-compatible.ts` | `OpenAICompatibleProvider` — shared base class for OpenAI-compatible providers |
@@ -73,7 +69,9 @@ The pipeline runs in four sequential phases, each implemented as a named async f
 | `src/providers/index.ts` | `createProvider` factory + barrel re-exports |
 | `src/web.ts` | Sitemap-based web content fetching; state persisted to `digests/web-state.json` |
 | `src/trending.ts` | GitHub Trending HTML scraper + Search API topic queries |
-| `src/hn.ts` | Hacker News top AI stories via Algolia HN Search API |
+| `src/link-utils.ts` | Canonical URL/title normalization and streaming duplicate rejection |
+| `src/hn.ts` | Scans Hacker News Firebase Top Stories in rank order for up to 30 unique AI links |
+| `src/radar.ts` | Deterministic scoring, editorial validation, fallback, stable ranking, and Top 5 selection |
 | `src/generate-manifest.ts` | Generates `manifest.json` (sidebar data for Web UI) and `feed.xml` (RSS 2.0 feed) |
 
 ## Report outputs
@@ -87,7 +85,8 @@ Files written to `digests/YYYY-MM-DD/`:
 | `ai-infra.md` | `infra` | Always generated |
 | `ai-web.md` | `web` | Skipped if no new sitemap content |
 | `ai-trending.md` | `trending` | Skipped if both data sources fail |
-| `ai-hn.md` | `hn` | Skipped if Algolia fetch fails |
+| `ai-hn.md` | `hn` | Skipped if the HN Top Stories fetch yields no data |
+| `ai-radar.md` | `radar` | Up to 30 unique HN candidates and Top 5 recommendations; skipped only when there are no candidates |
 
 ## Tracked sources
 
@@ -97,15 +96,16 @@ Files written to `digests/YYYY-MM-DD/`:
 - **CLAUDE_SKILLS_REPO**: anthropics/skills — no date filter, sorted by popularity
 - **Web**: anthropic.com + openai.com via sitemap, state in `digests/web-state.json`
 - **Trending**: github.com/trending (HTML) + GitHub Search API (6 AI topics, 7-day window)
-- **HN**: Algolia HN Search API — 6 parallel queries, top-30 AI stories by points, last 24h
+- **HN**: Firebase Top Stories — scanned in HN rank order until up to 30 canonical URL/title-unique AI links are accepted
 
 ## Key conventions
 
 - All bilingual strings (titles, labels, footers, messages) are centralized in `src/i18n.ts`. Use the `Lang` type (`"zh" | "en"`) and `Record<Lang, string>` maps. Do not add inline bilingual ternaries elsewhere.
 - LLM prompt builders are split across two files: `src/prompts.ts` (repo-level prompts) and `src/prompts-data.ts` (data-source prompts). Each report type has its own builder function.
 - Weekly and monthly rollups were removed in July 2026. `ai-weekly`/`ai-monthly` remain in `REPORT_LABELS` (`src/i18n.ts`) and `REPORT_FILES` (`src/generate-manifest.ts`) only so archived reports stay reachable — do not add generation code back.
-- `callLlm(prompt, maxTokens?)` defaults to 4096 tokens. Web report uses 8192, trending uses 6144. The table-formatted listing reports (HN, PH, ArXiv, HF, Community) use `LLM_TOKENS_LISTING` = 6144 to fit multi-row tables plus 2-sentence summaries.
-- Data-source listing reports (Trending, HN, PH, ArXiv, HF, Community) render their item lists as **Markdown tables** (not bullet lists). Numeric columns are copied verbatim from the fetched data; the summary column is 2 sentences. Tables already have CSS in `index.html` and render natively in GitHub Issues too.
+- `callLlm(prompt, maxTokens?)` defaults to 4096 tokens. Web report uses 8192; listing reports and the single Radar editorial request use `LLM_TOKENS_LISTING` = 6144.
+- Data-source listing reports render item lists as **Markdown tables**. Radar renders every sorted unique candidate exactly once in its table and a maximum of five unique recommendations in its Top 5 section.
+- Radar ranking is stable: total score descending, original HN rank ascending, then candidate ID ascending. Invalid or unavailable editorial output uses the deterministic base-score fallback rather than suppressing the reports.
 - On 429 rate-limit errors `callLlm` retries up to 3 times with exponential backoff (5 s / 10 s / 20 s); the concurrency slot is released during the wait.
 - The concurrency limiter (`LLM_CONCURRENCY = 5`) prevents 429s when many parallel LLM calls fire. Do not bypass it by calling SDK clients directly.
 - LLM provider is selected via `LLM_PROVIDER` env var (default: `anthropic`). Valid values: `anthropic`, `openai`, `github-copilot`, `openrouter`, `deepseek`.
@@ -131,4 +131,4 @@ Files written to `digests/YYYY-MM-DD/`:
 6. Add a label color entry in `LABEL_COLORS` in `src/github.ts`.
 7. Add the report ID and label to `REPORT_LABELS` in `src/i18n.ts` and `LABELS` in `index.html`.
 8. Add the report file name to `REPORT_FILES` in `src/generate-manifest.ts`.
-9. Update both README files and this file.
+9. Update `README.md` and the contributor instruction docs required by the task. Do not create `README.zh-CN.md`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,16 +34,18 @@ node --env-file=.env --import=tsx src/index.ts
 
 `GITHUB_TOKEN` belongs only to the current process and must not be written to `.env`. With `DIGEST_REPO` unset, reports are written locally and no GitHub Issues are created. Set `DIGEST_REPO=owner/repo` only for an intentional publishing run.
 
-The provider factory still defaults to `anthropic` when `LLM_PROVIDER` is absent. Supported providers are `anthropic`, `openai`, `github-copilot`, `openrouter`, and `deepseek`; their required keys are documented in `.env.example` and `README.md`.
+The provider factory still defaults to `anthropic` when `LLM_PROVIDER` is absent. Supported providers are `anthropic`, `openai`, `github-copilot`, `openrouter`, and `deepseek`. `README.md` is the complete provider/key matrix; `.env.example` is the preferred local DeepSeek example with commented Anthropic/OpenAI alternatives.
 
 ## Architecture
 
-The pipeline runs in four sequential phases, each implemented as a named async function in `src/index.ts`:
+The main flow has four major stages, but Radar intentionally overlaps the middle two rather than running as a sequential stage:
 
 1. **`fetchAllData`** — all network I/O in parallel: GitHub API (issues/PRs/releases) for 17 repos, Claude Code Skills, Anthropic/OpenAI sitemaps, GitHub Trending HTML + Search API, and Hacker News Firebase Top Stories.
 2. **`generateSummaries`** — per-repo LLM calls, all in parallel, rate-limited to 5 concurrent requests by a queue in `src/report.ts`.
-3. **Comparisons and Radar** — the existing comparison calls plus one bilingual Radar editorial request; Radar falls back to deterministic scoring if that request fails validation or exhausts retries.
+3. **Comparisons** — cross-tool CLI, OpenClaw cross-ecosystem, and infrastructure comparison calls.
 4. **Save phase** — report builders assemble Markdown; savers write bilingual files and create GitHub Issues only when `DIGEST_REPO` is explicitly set. `saveRadarReport` reuses the single shared Radar result for both languages.
+
+Immediately after fetch, `main()` creates one `radarDataPromise` for the bilingual editorial request. It runs while summaries and comparisons proceed, falls back to deterministic scoring if editorial validation or retries fail, and is awaited exactly once immediately before the save batch; both languages reuse that result.
 
 ## Source files
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,38 +16,34 @@ pnpm format         # Prettier --write src
 pnpm format:check   # Prettier --check src
 ```
 
-Required env vars for local runs:
+Preferred Windows local run (DeepSeek):
 
-```bash
-export GITHUB_TOKEN=ghp_xxxxx
-export DIGEST_REPO=owner/repo   # omit to skip GitHub issue creation
-
-# LLM provider (default: anthropic)
-export LLM_PROVIDER=anthropic   # anthropic | openai | github-copilot | openrouter | deepseek
-
-# Anthropic (default)
-export ANTHROPIC_API_KEY=sk-ant-xxxxx
-
-# OpenAI
-# export OPENAI_API_KEY=sk-xxxxx
-
-# GitHub Copilot — uses GITHUB_TOKEN
-
-# OpenRouter
-# export OPENROUTER_API_KEY=sk-or-xxxxx
-
-# DeepSeek
-# export DEEPSEEK_API_KEY=sk-xxxxx
+```dotenv
+LLM_PROVIDER=deepseek
+DEEPSEEK_API_KEY=sk-xxxxx
 ```
+
+Keep only the provider and its required key in the ignored `.env` file. Then run from PowerShell:
+
+```powershell
+corepack pnpm install --frozen-lockfile
+$env:GITHUB_TOKEN = gh auth token
+Remove-Item Env:DIGEST_REPO -ErrorAction SilentlyContinue
+node --env-file=.env --import=tsx src/index.ts
+```
+
+`GITHUB_TOKEN` belongs only to the current process and must not be written to `.env`. With `DIGEST_REPO` unset, reports are written locally and no GitHub Issues are created. Set `DIGEST_REPO=owner/repo` only for an intentional publishing run.
+
+The provider factory still defaults to `anthropic` when `LLM_PROVIDER` is absent. Supported providers are `anthropic`, `openai`, `github-copilot`, `openrouter`, and `deepseek`; their required keys are documented in `.env.example` and `README.md`.
 
 ## Architecture
 
 The pipeline runs in four sequential phases, each implemented as a named async function in `src/index.ts`:
 
-1. **`fetchAllData`** — all network I/O in parallel: GitHub API (issues/PRs/releases) for 17 repos, Claude Code Skills, Anthropic/OpenAI sitemaps, GitHub Trending HTML + Search API, Hacker News Algolia API.
+1. **`fetchAllData`** — all network I/O in parallel: GitHub API (issues/PRs/releases) for 17 repos, Claude Code Skills, Anthropic/OpenAI sitemaps, GitHub Trending HTML + Search API, and Hacker News Firebase Top Stories.
 2. **`generateSummaries`** — per-repo LLM calls, all in parallel, rate-limited to 5 concurrent requests by a queue in `src/report.ts`.
-3. **Comparisons** — two LLM calls: cross-tool CLI comparison and OpenClaw cross-ecosystem comparison.
-4. **Save phase** — `buildCliReportContent` / `buildOpenclawReportContent` / `buildInfraReportContent` (in `src/report-builders.ts`) build Markdown strings; `saveWebReport` / `saveTrendingReport` / `saveHnReport` (in `src/report-savers.ts`) call LLM + write file + create GitHub Issue.
+3. **Comparisons and Radar** — the existing comparison calls plus one bilingual Radar editorial request; Radar falls back to deterministic scoring if that request fails validation or exhausts retries.
+4. **Save phase** — report builders assemble Markdown; savers write bilingual files and create GitHub Issues only when `DIGEST_REPO` is explicitly set. `saveRadarReport` reuses the single shared Radar result for both languages.
 
 ## Source files
 
@@ -58,10 +54,10 @@ The pipeline runs in four sequential phases, each implemented as a named async f
 | `src/github.ts` | GitHub API helpers: `fetchRecentItems`, `fetchRecentReleases`, `fetchSkillsData`, `createGitHubIssue`; shared `RepoFetch` type |
 | `src/config.ts` | Loads `config.yml` into `RadarConfig` (`cliRepos`, `skillsRepo`, `openclaw`, `openclawPeers`, `infraRepos`); built-in defaults when a section is missing |
 | `src/prompts.ts` | LLM prompt builders for repo reports: `buildCliPrompt`, `buildPeerPrompt`, `buildInfraPrompt`, `buildComparisonPrompt`, `buildInfraComparisonPrompt`, `buildPeersComparisonPrompt`, `buildSkillsPrompt` |
-| `src/prompts-data.ts` | LLM prompt builders for data-source reports: `buildTrendingPrompt`, `buildWebReportPrompt`, `buildHnPrompt` |
+| `src/prompts-data.ts` | LLM prompt builders for data-source reports, including one bilingual `buildRadarPrompt` request for all Radar candidates |
 | `src/report.ts` | `callLlm` (with concurrency limiter), `saveFile`, `autoGenFooter` (uses i18n), LLM token budget constants |
-| `src/report-builders.ts` | `buildCliReportContent`, `buildOpenclawReportContent`, `buildInfraReportContent` — assemble final Markdown strings for CLI, OpenClaw and infra reports |
-| `src/report-savers.ts` | `saveWebReport`, `saveTrendingReport`, `saveHnReport` — LLM call + file save + optional GitHub issue |
+| `src/report-builders.ts` | Pure Markdown builders, including `buildRadarReportContent` for bilingual candidate tables and Top 5 sections |
+| `src/report-savers.ts` | Report save wrappers, including `saveRadarReport`; GitHub Issue creation is conditional on `DIGEST_REPO` |
 | `src/date.ts` | Date and timing utilities: `toCstDateStr`, `toUtcStr`, `sleep` |
 | `src/providers/types.ts` | `LlmProvider` interface, `ProviderName` type, `VALID_PROVIDER_NAMES` |
 | `src/providers/openai-compatible.ts` | `OpenAICompatibleProvider` — shared base class for OpenAI-compatible providers |
@@ -73,7 +69,9 @@ The pipeline runs in four sequential phases, each implemented as a named async f
 | `src/providers/index.ts` | `createProvider` factory + barrel re-exports |
 | `src/web.ts` | Sitemap-based web content fetching; state persisted to `digests/web-state.json` |
 | `src/trending.ts` | GitHub Trending HTML scraper + Search API topic queries |
-| `src/hn.ts` | Hacker News top AI stories via Algolia HN Search API |
+| `src/link-utils.ts` | Canonical URL/title normalization and streaming duplicate rejection |
+| `src/hn.ts` | Scans Hacker News Firebase Top Stories in rank order for up to 30 unique AI links |
+| `src/radar.ts` | Deterministic scoring, editorial validation, fallback, stable ranking, and Top 5 selection |
 | `src/generate-manifest.ts` | Generates `manifest.json` (sidebar data for Web UI) and `feed.xml` (RSS 2.0 feed) |
 
 ## Report outputs
@@ -87,7 +85,8 @@ Files written to `digests/YYYY-MM-DD/`:
 | `ai-infra.md` | `infra` | Always generated |
 | `ai-web.md` | `web` | Skipped if no new sitemap content |
 | `ai-trending.md` | `trending` | Skipped if both data sources fail |
-| `ai-hn.md` | `hn` | Skipped if Algolia fetch fails |
+| `ai-hn.md` | `hn` | Skipped if the HN Top Stories fetch yields no data |
+| `ai-radar.md` | `radar` | Up to 30 unique HN candidates and Top 5 recommendations; skipped only when there are no candidates |
 
 ## Tracked sources
 
@@ -97,15 +96,16 @@ Files written to `digests/YYYY-MM-DD/`:
 - **CLAUDE_SKILLS_REPO**: anthropics/skills — no date filter, sorted by popularity
 - **Web**: anthropic.com + openai.com via sitemap, state in `digests/web-state.json`
 - **Trending**: github.com/trending (HTML) + GitHub Search API (6 AI topics, 7-day window)
-- **HN**: Algolia HN Search API — 6 parallel queries, top-30 AI stories by points, last 24h
+- **HN**: Firebase Top Stories — scanned in HN rank order until up to 30 canonical URL/title-unique AI links are accepted
 
 ## Key conventions
 
 - All bilingual strings (titles, labels, footers, messages) are centralized in `src/i18n.ts`. Use the `Lang` type (`"zh" | "en"`) and `Record<Lang, string>` maps. Do not add inline bilingual ternaries elsewhere.
 - LLM prompt builders are split across two files: `src/prompts.ts` (repo-level prompts) and `src/prompts-data.ts` (data-source prompts). Each report type has its own builder function.
 - Weekly and monthly rollups were removed in July 2026. `ai-weekly`/`ai-monthly` remain in `REPORT_LABELS` (`src/i18n.ts`) and `REPORT_FILES` (`src/generate-manifest.ts`) only so archived reports stay reachable — do not add generation code back.
-- `callLlm(prompt, maxTokens?)` defaults to 4096 tokens. Web report uses 8192, trending uses 6144. The table-formatted listing reports (HN, PH, ArXiv, HF, Community) use `LLM_TOKENS_LISTING` = 6144 to fit multi-row tables plus 2-sentence summaries.
-- Data-source listing reports (Trending, HN, PH, ArXiv, HF, Community) render their item lists as **Markdown tables** (not bullet lists). Numeric columns are copied verbatim from the fetched data; the summary column is 2 sentences. Tables already have CSS in `index.html` and render natively in GitHub Issues too.
+- `callLlm(prompt, maxTokens?)` defaults to 4096 tokens. Web report uses 8192; listing reports and the single Radar editorial request use `LLM_TOKENS_LISTING` = 6144.
+- Data-source listing reports render item lists as **Markdown tables**. Radar renders every sorted unique candidate exactly once in its table and a maximum of five unique recommendations in its Top 5 section.
+- Radar ranking is stable: total score descending, original HN rank ascending, then candidate ID ascending. Invalid or unavailable editorial output uses the deterministic base-score fallback rather than suppressing the reports.
 - On 429 rate-limit errors `callLlm` retries up to 3 times with exponential backoff (5 s / 10 s / 20 s); the concurrency slot is released during the wait.
 - The concurrency limiter (`LLM_CONCURRENCY = 5`) prevents 429s when many parallel LLM calls fire. Do not bypass it by calling SDK clients directly.
 - LLM provider is selected via `LLM_PROVIDER` env var (default: `anthropic`). Valid values: `anthropic`, `openai`, `github-copilot`, `openrouter`, `deepseek`.
@@ -131,4 +131,4 @@ Files written to `digests/YYYY-MM-DD/`:
 6. Add a label color entry in `LABEL_COLORS` in `src/github.ts`.
 7. Add the report ID and label to `REPORT_LABELS` in `src/i18n.ts` and `LABELS` in `index.html`.
 8. Add the report file name to `REPORT_FILES` in `src/generate-manifest.ts`.
-9. Update both README files and this file.
+9. Update `README.md` and the contributor instruction docs required by the task. Do not create `README.zh-CN.md`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,16 +34,18 @@ node --env-file=.env --import=tsx src/index.ts
 
 `GITHUB_TOKEN` belongs only to the current process and must not be written to `.env`. With `DIGEST_REPO` unset, reports are written locally and no GitHub Issues are created. Set `DIGEST_REPO=owner/repo` only for an intentional publishing run.
 
-The provider factory still defaults to `anthropic` when `LLM_PROVIDER` is absent. Supported providers are `anthropic`, `openai`, `github-copilot`, `openrouter`, and `deepseek`; their required keys are documented in `.env.example` and `README.md`.
+The provider factory still defaults to `anthropic` when `LLM_PROVIDER` is absent. Supported providers are `anthropic`, `openai`, `github-copilot`, `openrouter`, and `deepseek`. `README.md` is the complete provider/key matrix; `.env.example` is the preferred local DeepSeek example with commented Anthropic/OpenAI alternatives.
 
 ## Architecture
 
-The pipeline runs in four sequential phases, each implemented as a named async function in `src/index.ts`:
+The main flow has four major stages, but Radar intentionally overlaps the middle two rather than running as a sequential stage:
 
 1. **`fetchAllData`** — all network I/O in parallel: GitHub API (issues/PRs/releases) for 17 repos, Claude Code Skills, Anthropic/OpenAI sitemaps, GitHub Trending HTML + Search API, and Hacker News Firebase Top Stories.
 2. **`generateSummaries`** — per-repo LLM calls, all in parallel, rate-limited to 5 concurrent requests by a queue in `src/report.ts`.
-3. **Comparisons and Radar** — the existing comparison calls plus one bilingual Radar editorial request; Radar falls back to deterministic scoring if that request fails validation or exhausts retries.
+3. **Comparisons** — cross-tool CLI, OpenClaw cross-ecosystem, and infrastructure comparison calls.
 4. **Save phase** — report builders assemble Markdown; savers write bilingual files and create GitHub Issues only when `DIGEST_REPO` is explicitly set. `saveRadarReport` reuses the single shared Radar result for both languages.
+
+Immediately after fetch, `main()` creates one `radarDataPromise` for the bilingual editorial request. It runs while summaries and comparisons proceed, falls back to deterministic scoring if editorial validation or retries fail, and is awaited exactly once immediately before the save batch; both languages reuse that result.
 
 ## Source files
 

--- a/README.md
+++ b/README.md
@@ -439,7 +439,7 @@ Community sentiment signals
 Worth reading
 ```
 
-Historical digests are stored in [`digests/`](./digests/). Published issues are tagged by type: [`digest`](../../issues?label=digest) · [`openclaw`](../../issues?label=openclaw) · [`web`](../../issues?label=web) · [`trending`](../../issues?label=trending) · [`hn`](../../issues?label=hn) · [`ph`](../../issues?label=ph) · [`arxiv`](../../issues?label=arxiv) · [`hf`](../../issues?label=hf) · [`community`](../../issues?label=community).
+Historical digests are stored in [`digests/`](./digests/). Published issues are tagged by type: [`digest`](../../issues?label=digest) · [`openclaw`](../../issues?label=openclaw) · [`web`](../../issues?label=web) · [`trending`](../../issues?label=trending) · [`hn`](../../issues?label=hn) · [`radar`](../../issues?label=radar) · [`ph`](../../issues?label=ph) · [`arxiv`](../../issues?label=arxiv) · [`hf`](../../issues?label=hf) · [`community`](../../issues?label=community).
 
 Weekly and monthly rollup reports were discontinued in July 2026; past ones remain browsable under `digests/` and in the Web UI.
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ A GitHub Actions workflow that runs every morning at 08:00 CST. It aggregates AI
 | [GitHub Repos](https://github.com) | API | Issues, PRs, releases from 17+ tracked AI tool repos |
 | [Claude Code Skills](https://github.com/anthropics/skills) | API | Trending skills sorted by community engagement |
 | [GitHub Trending](https://github.com/trending) | HTML + API | Daily trending repos + AI topic search (7-day window) |
-| [Hacker News](https://news.ycombinator.com) | [Algolia API](https://hn.algolia.com/api) | Top 30 AI stories from last 24h, 6 parallel queries |
+| [Hacker News](https://news.ycombinator.com) | [Firebase API](https://github.com/HackerNews/API) | Top Stories scanned in rank order for up to 30 unique AI links |
 | [Product Hunt](https://www.producthunt.com) | GraphQL API | Yesterday's top AI products by votes |
 | [ArXiv](https://arxiv.org) | [ArXiv API](https://export.arxiv.org/api/query) | Latest papers from cs.AI, cs.CL, cs.LG (last 48h) |
 | [Hugging Face](https://huggingface.co) | [Hub API](https://huggingface.co/api/models) | 30 trending models sorted by weekly likes |
@@ -183,7 +183,7 @@ The LLM filters out non-AI repos from the trending list, classifies the rest by 
 
 ### Hacker News
 
-Top AI stories from the last 24 hours, fetched via the [Algolia HN Search API](https://hn.algolia.com/api). Six queries run in parallel (`AI`, `LLM`, `Claude`, `OpenAI`, `Anthropic`, `machine learning`), results are deduplicated and ranked by points. The top 30 stories are passed to the LLM for analysis.
+Hacker News [Top Stories](https://github.com/HackerNews/API) are scanned in rank order. AI-related links are normalized and deduplicated by canonical URL and title until up to 30 unique candidates are accepted; scanning continues past duplicates when more stories are available.
 
 ### Official web content (sitemap-based)
 
@@ -203,7 +203,8 @@ New articles are detected by comparing sitemap `lastmod` timestamps against a pe
 - Tracks 6 AI infrastructure projects (inference engines, gateways, fine-tuning) with a dedicated report and cross-project comparison
 - Scrapes official Anthropic and OpenAI web content via sitemaps; detects new articles incrementally
 - Monitors GitHub Trending daily + searches 6 AI topic tags; classifies repos by dimension and extracts trend signals
-- Fetches top-30 AI stories from Hacker News (last 24h, ranked by points); generates community sentiment report
+- Scans Hacker News Top Stories for up to 30 canonical URL/title-unique AI links
+- Generates bilingual AI Radar reports with all unique candidates and a stable Top 5, falling back to deterministic scoring if editorial output is unavailable or invalid
 - Publishes GitHub Issues for each report type; commits Markdown files to `digests/YYYY-MM-DD/`
 - Runs on a daily schedule via GitHub Actions; supports manual triggering
 - All tracked repositories are configurable via `config.yml` — no code changes needed
@@ -243,12 +244,13 @@ Go to **Settings → Secrets and variables → Actions** and add:
 
 | Secret | Required | Description |
 |--------|----------|-------------|
-| `LLM_PROVIDER` | optional | `anthropic` (default), `openai`, `github-copilot`, or `openrouter` |
+| `LLM_PROVIDER` | optional | `anthropic` (default), `openai`, `github-copilot`, `openrouter`, or `deepseek` |
 | `ANTHROPIC_API_KEY` | if Anthropic | API key — works with both Anthropic and Kimi Code |
 | `ANTHROPIC_BASE_URL` | optional | API endpoint override. Set to `https://api.kimi.com/coding/` for Kimi Code; leave unset for Anthropic |
 | `OPENAI_API_KEY` | if OpenAI | OpenAI API key |
 | `OPENAI_BASE_URL` | optional | OpenAI endpoint override |
 | `OPENROUTER_API_KEY` | if OpenRouter | OpenRouter API key |
+| `DEEPSEEK_API_KEY` | if DeepSeek | DeepSeek API key |
 | `TELEGRAM_BOT_TOKEN` | optional | Telegram bot token from [@BotFather](https://t.me/BotFather). If set, a message is sent after each digest run |
 | `TELEGRAM_CHAT_ID` | optional | Telegram chat/channel/group ID to send notifications to |
 | `FEISHU_WEBHOOK_URLS` | optional | Comma-separated Feishu custom bot webhook URLs. If set, a card message is sent to each group after each digest run |
@@ -281,36 +283,33 @@ Set `LLM_PROVIDER` to choose which model backend powers the digest generation. D
 | OpenAI | `openai` | `OPENAI_API_KEY` | `gpt-4o` |
 | GitHub Copilot | `github-copilot` | `GITHUB_TOKEN` | `gpt-4o` |
 | OpenRouter | `openrouter` | `OPENROUTER_API_KEY` | `anthropic/claude-sonnet-4` |
+| DeepSeek | `deepseek` | `DEEPSEEK_API_KEY` | `deepseek-v4-flash` |
 
-Override the model name with `ANTHROPIC_MODEL`, `OPENAI_MODEL`, `GITHUB_COPILOT_MODEL`, or `OPENROUTER_MODEL` respectively.
+Override the model name with `ANTHROPIC_MODEL`, `OPENAI_MODEL`, `GITHUB_COPILOT_MODEL`, `OPENROUTER_MODEL`, or `DEEPSEEK_MODEL` respectively.
 
 The provider abstraction lives in `src/providers/` — each provider is a separate file implementing the `LlmProvider` interface. Adding a new provider only requires creating a new file and registering it in the factory.
 
 ## Running locally
 
-```bash
-pnpm install
+Copy `.env.example` to the ignored `.env` file. For the preferred DeepSeek setup, keep only the provider and its key in that file:
 
-export GITHUB_TOKEN=ghp_xxxxx
-
-# Option A: Anthropic (default)
-export ANTHROPIC_API_KEY=sk-ant-xxxxxxxx
-
-# Option B: OpenAI
-# export LLM_PROVIDER=openai
-# export OPENAI_API_KEY=sk-xxxxxxxx
-
-# Option C: GitHub Copilot (uses GITHUB_TOKEN)
-# export LLM_PROVIDER=github-copilot
-
-# Option D: OpenRouter
-# export LLM_PROVIDER=openrouter
-# export OPENROUTER_API_KEY=sk-or-xxxxxxxx
-
-export DIGEST_REPO=your-username/agents-radar  # optional; omit to only write files
-
-pnpm start
+```dotenv
+LLM_PROVIDER=deepseek
+DEEPSEEK_API_KEY=sk-xxxxx
 ```
+
+Then run the complete pipeline from Windows PowerShell:
+
+```powershell
+corepack pnpm install --frozen-lockfile
+$env:GITHUB_TOKEN = gh auth token
+Remove-Item Env:DIGEST_REPO -ErrorAction SilentlyContinue
+node --env-file=.env --import=tsx src/index.ts
+```
+
+`GITHUB_TOKEN` is assigned only to the current PowerShell process; do not store it in `.env`. Clearing `DIGEST_REPO` keeps the run local and prevents GitHub Issue creation. Set `DIGEST_REPO=owner/repo` explicitly only when publishing Issues is intended.
+
+The run writes the bilingual Radar reports `ai-radar.md` and `ai-radar-en.md` under `digests/YYYY-MM-DD/`. They contain up to 30 unique Hacker News AI candidates and a Top 5 recommendation list; when fewer unique candidates are available, the reports show the actual count.
 
 ## Output format
 
@@ -324,6 +323,7 @@ Files are written to `digests/YYYY-MM-DD/`:
 | `ai-web.md` | Official web content report (only written when new content exists) | `web` |
 | `ai-trending.md` | GitHub AI trending report — repos classified by dimension + trend signals (only written when data is available) | `trending` |
 | `ai-hn.md` | Hacker News AI community digest — top stories + sentiment analysis (only written when fetch succeeds) | `hn` |
+| `ai-radar.md` | AI information Radar - up to 30 unique HN candidates + Top 5 recommendations (only written when candidates are available) | `radar` |
 | `ai-ph.md` | Product Hunt AI products digest (only written when `PRODUCTHUNT_TOKEN` is set and data is available) | `ph` |
 | `ai-arxiv.md` | ArXiv AI research digest — key papers from cs.AI/cs.CL/cs.LG | `arxiv` |
 | `ai-hf.md` | Hugging Face trending models digest — sorted by weekly likes | `hf` |
@@ -427,7 +427,7 @@ Community focus
 
 `ai-hn.md` / `ai-hn-en.md` structure:
 ```
-Sources: Hacker News (top-30 AI stories, last 24h)
+Sources: Hacker News Top Stories (up to 30 unique AI links)
 
 Today's summary
 Top stories & discussions

--- a/docs/superpowers/plans/2026-08-12-agents-radar-top5-implementation.md
+++ b/docs/superpowers/plans/2026-08-12-agents-radar-top5-implementation.md
@@ -1,0 +1,1572 @@
+# Agents Radar Top 5 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 先在 Windows 本机按上游入口复现 `agents-radar`，再新增一个每日抓取最多 30 条唯一 Hacker News AI 链接、可解释打分并固定推荐 Top 5 的中英双语 Radar 报告。
+
+**Architecture:** 保留现有 `fetch → summarize → save → publish` 主流程和全部既有报告，先完成零代码改动的上游基线运行。增强部分在 HN 抓取层完成流式去重，在纯函数模块中完成确定性评分、DeepSeek 结果验证、稳定排序和降级，再通过现有报告保存、manifest、RSS、网页和通知边界接入。
+
+**Tech Stack:** Node.js 24（仅在确认版本问题时切换 Node.js 22）、TypeScript 5.7、pnpm 9.15.9、Vitest 4、DeepSeek OpenAI-compatible API、Hacker News Firebase API、GitHub CLI。
+
+## Global Constraints
+
+- 必须先成功运行上游基线；只有账号、依赖、网络、硬件或外部服务限制被实际确认后，才能启用确定性保真降级。
+- 本地基线与首轮 Radar 验证均不得设置 `DIGEST_REPO`，不得创建 GitHub Issues 或推送提交。
+- 使用 `pnpm@9.15.9` 和 frozen lockfile；先用 Node.js 24，仅在错误可归因于 Node 版本时切换到上游 CI 使用的 Node.js 22。
+- LLM Provider 固定为 `deepseek`；`.env` 只保存 `LLM_PROVIDER=deepseek` 和 `DEEPSEEK_API_KEY`，且不得提交。
+- `GITHUB_TOKEN` 不写入 `.env`，只从有效的 `gh auth token` 注入当前进程；日志、测试快照、错误和报告不得包含任何密钥内容。
+- 第一版只使用 Hacker News Top Stories；不引入数据库、Docker、浏览器自动化、本地模型或新的运行时依赖。
+- 数据充足时输出 30 条唯一候选和恰好 5 条唯一推荐；数据不足时报告实际数量，不伪造、不复制补齐。
+- 确定性基础分为 0–70：points 0–25、comments 0–10、HN rank 0–20、freshness 0–15；DeepSeek 编辑分为 0–30：relevance、novelty、actionability 各 0–10。
+- DeepSeek 请求失败、429 重试耗尽、JSON 无法修复或结构校验失败时，使用 `baseScore / 70 * 100` 的确定性总分，并仍按稳定规则输出 Top 5。
+- 排序键固定为总分降序、原始 HN 排名升序、候选 ID 升序；最终展示分四舍五入到一位小数。
+- 不改变既有日报文件名、输出结构或发布行为；自动生成的基线日报与首轮验证日报不进入功能提交。
+
+## File Structure
+
+| File | Responsibility |
+| --- | --- |
+| `src/link-utils.ts` | URL/标题规范化和可复用的流式去重状态。 |
+| `src/hn.ts` | 扫描 HN Top Stories，过滤 AI 条目，遇到重复继续扫描直到最多 30 条唯一链接。 |
+| `src/radar.ts` | Radar 类型、基础评分、DeepSeek 结构校验、降级、稳定排序和 Top 5。 |
+| `src/prompts-data.ts` | 一次性生成全候选双语编辑评分的结构化 Prompt。 |
+| `src/report-builders.ts` | 纯函数构建 `ai-radar.md` / `ai-radar-en.md` 内容。 |
+| `src/report-savers.ts` | 保存双语 Radar 文件，并在明确配置 `DIGEST_REPO` 时复用现有 Issue 发布流程。 |
+| `src/index.ts` | 发起一次 Radar 编辑评分、处理降级、保存双语报告并纳入 highlights。 |
+| `src/i18n.ts` | Radar 标题、段落、模式、Issue、manifest 与通知双语文案。 |
+| `src/generate-manifest.ts` | 将 `ai-radar` / `ai-radar-en` 注册到 manifest 和 RSS 白名单。 |
+| `index.html` | 将 Radar 注册到现有静态站侧栏标签。 |
+| `.env.example`, `README.md` | 补齐 DeepSeek 与 Windows 本地运行说明，不包含真实密钥。 |
+| `src/__tests__/link-utils.test.ts` | URL、标题和重复判定单元测试。 |
+| `src/__tests__/hn.test.ts` | 去重后继续扫描、单条失败继续和统计字段测试。 |
+| `src/__tests__/radar.test.ts` | 评分边界、结构校验、降级、稳定排序和 Top 5 测试。 |
+| `src/__tests__/prompt-builders.test.ts` | Radar Prompt 的候选覆盖与 JSON 合同测试。 |
+| `src/__tests__/report-builders.test.ts` | 双语报告结构、唯一性和候选不足测试。 |
+| `src/__tests__/i18n.test.ts`, `src/__tests__/generate-manifest.test.ts` | 发现面与双语注册回归测试。 |
+
+---
+
+### Task 1: Reproduce the Upstream Baseline Safely
+
+**Files:**
+- Read: `package.json`
+- Read: `.env.example`
+- Runtime output only: `digests/2026-08-12/`
+- Runtime log only: `C:\Users\胡宇\agents-radar-baseline-2026-08-12.log`
+
+**Interfaces:**
+- Consumes: existing `pnpm start` behavior, a valid GitHub CLI session, and a user-entered DeepSeek key.
+- Produces: verified upstream reports and a secret-free baseline log; no source commit.
+
+- [ ] **Step 1: Confirm the repository starts from the approved documents and no unrelated changes**
+
+Run:
+
+```powershell
+git status --short --branch
+git log -2 --oneline
+```
+
+Expected: `master` is ahead of `origin/master` only by the approved design/plan documentation commits; no untracked source changes are present.
+
+- [ ] **Step 2: Activate the package-manager version declared by upstream and install the frozen dependency graph**
+
+Run:
+
+```powershell
+corepack pnpm --version
+corepack pnpm install --frozen-lockfile
+```
+
+Expected: the first command prints `9.15.9`, and installation exits 0 without changing `pnpm-lock.yaml`.
+
+- [ ] **Step 3: Run the upstream quality gates before using credentials**
+
+Run:
+
+```powershell
+corepack pnpm format:check
+corepack pnpm lint
+corepack pnpm typecheck
+corepack pnpm test
+```
+
+Expected: all four commands exit 0. If any command fails, invoke `superpowers:systematic-debugging`, identify whether the failure is upstream, environment, or Node-version-specific, and do not install arbitrary replacements.
+
+- [ ] **Step 4: Repair GitHub CLI authentication without printing the token**
+
+Run:
+
+```powershell
+gh auth status --hostname github.com
+```
+
+If the session remains invalid, run:
+
+```powershell
+gh auth login --hostname github.com --git-protocol https --web
+gh auth status --hostname github.com
+```
+
+Expected: GitHub CLI reports an authenticated account. Never run `gh auth token` as a standalone display command.
+
+- [ ] **Step 5: Let the user enter the DeepSeek key in the ignored local file**
+
+Create `C:\Users\胡宇\agents-radar\.env` with exactly these two assignments, entering the real value locally in the editor rather than chat or shell history:
+
+```dotenv
+LLM_PROVIDER=deepseek
+DEEPSEEK_API_KEY=<the value entered locally by the user>
+```
+
+Run:
+
+```powershell
+git check-ignore .env
+node --env-file=.env -e "if (process.env.LLM_PROVIDER !== 'deepseek' || !process.env.DEEPSEEK_API_KEY) process.exit(1); console.log('DeepSeek environment is present')"
+```
+
+Expected: `.env` is ignored and the second command prints only `DeepSeek environment is present`, never the key.
+
+- [ ] **Step 6: Run the exact upstream entry with local-only publishing behavior**
+
+In one PowerShell process, run these lines:
+
+```powershell
+$env:GITHUB_TOKEN = gh auth token
+Remove-Item Env:DIGEST_REPO -ErrorAction SilentlyContinue
+node --env-file=.env --import=tsx src/index.ts 2>&1 | Tee-Object -FilePath 'C:\Users\胡宇\agents-radar-baseline-2026-08-12.log'
+```
+
+Expected: exit code 0, final log line `Done!`, provider log `deepseek`, and no `Created ... issue` lines.
+
+- [ ] **Step 7: Verify baseline artifacts and scan the log for credential-shaped strings**
+
+Run:
+
+```powershell
+Get-ChildItem 'digests\2026-08-12' -Name
+Select-String -Path 'C:\Users\胡宇\agents-radar-baseline-2026-08-12.log' -Pattern 'sk-[A-Za-z0-9_-]{12,}|github_pat_[A-Za-z0-9_]{12,}|gh[pousr]_[A-Za-z0-9]{12,}'
+git status --short
+git diff --stat
+```
+
+Expected: at least `ai-cli.md`, `ai-agents.md`, `ai-infra.md`, `ai-hn.md` and their English variants exist; the secret scan returns no match; changes are limited to expected generated digest/state files. Do not stage or commit these generated files.
+
+### Task 2: Add Canonical Link Identity and Streaming Deduplication
+
+**Files:**
+- Create: `src/link-utils.ts`
+- Create: `src/__tests__/link-utils.test.ts`
+
+**Interfaces:**
+- Consumes: `{ title: string; url: string }` link-like values.
+- Produces: `normalizeUrl(rawUrl: string): string`, `normalizeTitle(title: string): string`, `createLinkDedupeState(): LinkDedupeState`, and `acceptUniqueLink(link: LinkLike, state: LinkDedupeState): boolean`.
+
+- [ ] **Step 1: Write failing normalization and duplicate tests**
+
+Create `src/__tests__/link-utils.test.ts`:
+
+```ts
+import { describe, expect, it } from "vitest";
+import {
+  acceptUniqueLink,
+  createLinkDedupeState,
+  normalizeTitle,
+  normalizeUrl,
+} from "../link-utils.ts";
+
+describe("normalizeUrl", () => {
+  it("normalizes host, ports, fragments, tracking parameters, query order, and trailing slash", () => {
+    expect(
+      normalizeUrl("HTTPS://Example.COM:443/path/?utm_source=x&b=2&a=1&ref=hn#section"),
+    ).toBe("https://example.com/path?a=1&b=2");
+  });
+
+  it("keeps the root slash and removes click identifiers", () => {
+    expect(normalizeUrl("https://Example.com/?gclid=abc&fbclid=def")).toBe("https://example.com/");
+  });
+});
+
+describe("normalizeTitle", () => {
+  it("folds case, punctuation, unicode width, and whitespace", () => {
+    expect(normalizeTitle("  ＡI—Agents:  A New Era! ")).toBe("ai agents a new era");
+  });
+});
+
+describe("acceptUniqueLink", () => {
+  it("rejects either a canonical URL duplicate or a normalized-title duplicate", () => {
+    const state = createLinkDedupeState();
+    expect(acceptUniqueLink({ title: "Alpha", url: "https://example.com/a?utm_source=hn" }, state)).toBe(true);
+    expect(acceptUniqueLink({ title: "Beta", url: "https://EXAMPLE.com/a" }, state)).toBe(false);
+    expect(acceptUniqueLink({ title: "ALPHA!", url: "https://example.com/b" }, state)).toBe(false);
+    expect(state.duplicateCount).toBe(2);
+  });
+});
+```
+
+- [ ] **Step 2: Run the focused test and verify the missing-module failure**
+
+Run:
+
+```powershell
+corepack pnpm vitest run src/__tests__/link-utils.test.ts
+```
+
+Expected: FAIL because `../link-utils.ts` does not exist.
+
+- [ ] **Step 3: Implement URL/title normalization and stateful duplicate admission**
+
+Create `src/link-utils.ts`:
+
+```ts
+export interface LinkLike {
+  title: string;
+  url: string;
+}
+
+export interface LinkDedupeState {
+  seenUrls: Set<string>;
+  seenTitles: Set<string>;
+  duplicateCount: number;
+}
+
+const TRACKING_PARAMS = new Set(["ref", "source", "fbclid", "gclid"]);
+
+export function normalizeUrl(rawUrl: string): string {
+  const url = new URL(rawUrl);
+  url.hostname = url.hostname.toLowerCase();
+  if ((url.protocol === "https:" && url.port === "443") || (url.protocol === "http:" && url.port === "80")) {
+    url.port = "";
+  }
+  url.hash = "";
+  for (const key of [...url.searchParams.keys()]) {
+    const lower = key.toLowerCase();
+    if (lower.startsWith("utm_") || TRACKING_PARAMS.has(lower)) url.searchParams.delete(key);
+  }
+  url.searchParams.sort();
+  if (url.pathname !== "/") url.pathname = url.pathname.replace(/\/+$/, "");
+  return url.toString();
+}
+
+export function normalizeTitle(title: string): string {
+  return title.normalize("NFKC").toLowerCase().replace(/[^\p{L}\p{N}]+/gu, " ").trim();
+}
+
+export function createLinkDedupeState(): LinkDedupeState {
+  return { seenUrls: new Set(), seenTitles: new Set(), duplicateCount: 0 };
+}
+
+export function acceptUniqueLink(link: LinkLike, state: LinkDedupeState): boolean {
+  const urlKey = normalizeUrl(link.url);
+  const titleKey = normalizeTitle(link.title);
+  if (state.seenUrls.has(urlKey) || state.seenTitles.has(titleKey)) {
+    state.duplicateCount += 1;
+    return false;
+  }
+  state.seenUrls.add(urlKey);
+  state.seenTitles.add(titleKey);
+  return true;
+}
+```
+
+- [ ] **Step 4: Run the focused test and the type checker**
+
+Run:
+
+```powershell
+corepack pnpm vitest run src/__tests__/link-utils.test.ts
+corepack pnpm typecheck
+```
+
+Expected: both commands exit 0.
+
+- [ ] **Step 5: Commit the independently verified link identity layer**
+
+```powershell
+git add src/link-utils.ts src/__tests__/link-utils.test.ts
+git commit -m "feat: add canonical link deduplication"
+```
+
+### Task 3: Make Hacker News Fill Up to 30 Unique Candidates
+
+**Files:**
+- Modify: `src/hn.ts`
+- Modify: `src/__tests__/hn.test.ts`
+- Modify: `src/index.ts` only for the existing empty `HnData` fallback shape
+- Modify: `src/__tests__/prompt-builders.test.ts` only for existing `HnData` fixture shapes
+
+**Interfaces:**
+- Consumes: `acceptUniqueLink()` from Task 2 and HN Top Stories in original rank order.
+- Produces: `HnData { stories, fetchSuccess, scannedCount, duplicateCount }`, with `stories.length <= 30` and unique canonical URL/title keys.
+
+- [ ] **Step 1: Extend HN tests with statistics, duplicate replacement, and item failure behavior**
+
+Update the existing assertions so every expected `HnData` includes `scannedCount` and `duplicateCount`. Use a 32-item mock where ID 102 duplicates ID 101 after URL normalization, and add these tests:
+
+```ts
+it("continues scanning until it has 30 unique AI links", async () => {
+  const ids = Array.from({ length: 32 }, (_, index) => 101 + index);
+  vi.spyOn(globalThis, "fetch").mockImplementation(async (input) => {
+    const url = String(input);
+    if (url.endsWith("/topstories.json")) return jsonResponse(ids);
+    const id = Number(url.match(/item\/(\d+)\.json$/)?.[1]);
+    const offset = id - 101;
+    return jsonResponse({
+      id,
+      type: "story",
+      by: "author",
+      time: 1_800_000_000 + offset,
+      title: offset === 1 ? "A different AI headline" : `AI story ${offset}`,
+      score: 100 - offset,
+      descendants: offset,
+      url: offset === 1 ? "https://EXAMPLE.com/ai-0?utm_source=hn" : `https://example.com/ai-${offset}`,
+    });
+  });
+
+  const result = await fetchHnData();
+  expect(result.stories).toHaveLength(30);
+  expect(result.stories.at(-1)?.id).toBe("131");
+  expect(result.duplicateCount).toBe(1);
+  expect(result.scannedCount).toBe(32);
+});
+
+it("keeps the higher-ranked story when normalized titles collide", async () => {
+  vi.spyOn(globalThis, "fetch").mockImplementation(async (input) => {
+    const url = String(input);
+    if (url.endsWith("/topstories.json")) return jsonResponse([301, 302, 303]);
+    const id = Number(url.match(/item\/(\d+)\.json$/)?.[1]);
+    const items = {
+      301: { id: 301, type: "story", title: "AI Launch!", url: "https://example.com/a" },
+      302: { id: 302, type: "story", title: "ai launch", url: "https://example.com/b" },
+      303: { id: 303, type: "story", title: "AI compiler", url: "https://example.com/c" },
+    };
+    return jsonResponse(items[id as keyof typeof items]);
+  });
+
+  const result = await fetchHnData();
+  expect(result.stories.map((story) => story.id)).toEqual(["301", "303"]);
+  expect(result.stories.map((story) => story.hnRank)).toEqual([1, 3]);
+  expect(result.duplicateCount).toBe(1);
+});
+
+it("logs one failed item and continues with the remaining batch", async () => {
+  vi.spyOn(console, "error").mockImplementation(() => undefined);
+  vi.spyOn(globalThis, "fetch").mockImplementation(async (input) => {
+    const url = String(input);
+    if (url.endsWith("/topstories.json")) return jsonResponse([201, 202]);
+    if (url.endsWith("/item/201.json")) return jsonResponse({ error: "failed" }, 503);
+    return jsonResponse({
+      id: 202,
+      type: "story",
+      title: "AI compiler",
+      url: "https://example.com/compiler",
+      score: 10,
+      descendants: 2,
+    });
+  });
+
+  const result = await fetchHnData();
+  expect(result.stories.map((story) => story.id)).toEqual(["202"]);
+  expect(console.error).toHaveBeenCalledWith("  [hn] item 201: HTTP 503");
+});
+```
+
+- [ ] **Step 2: Run the HN test and verify it fails on the missing statistics/continued scan**
+
+Run:
+
+```powershell
+corepack pnpm vitest run src/__tests__/hn.test.ts
+```
+
+Expected: FAIL because `HnData` lacks `scannedCount`/`duplicateCount` and the existing loop stops based on raw accepted AI story count.
+
+- [ ] **Step 3: Add required statistics and stream deduplication to `fetchHnData`**
+
+In `src/hn.ts`, import Task 2 helpers and change the data contract:
+
+```ts
+import { acceptUniqueLink, createLinkDedupeState } from "./link-utils.ts";
+
+export interface HnData {
+  stories: HnStory[];
+  fetchSuccess: boolean;
+  scannedCount: number;
+  duplicateCount: number;
+}
+```
+
+Initialize `scannedCount` and `dedupeState`, increment `scannedCount` by each requested batch size, and admit a story only through `acceptUniqueLink`:
+
+```ts
+const stories: HnStory[] = [];
+const dedupeState = createLinkDedupeState();
+let scannedCount = 0;
+
+for (let i = 0; i < topIds.length && stories.length < HN_TOP_STORIES; i += HN_BATCH_SIZE) {
+  const batchIds = topIds.slice(i, i + HN_BATCH_SIZE);
+  scannedCount += batchIds.length;
+  const items = await Promise.all(
+    batchIds.map(async (id): Promise<HnFirebaseItem | null> => {
+      const resp = await fetch(HN_ITEM_URL(id), {
+        headers: { "User-Agent": "agents-radar/1.0" },
+      });
+      if (!resp.ok) {
+        console.error(`  [hn] item ${id}: HTTP ${resp.status}`);
+        return null;
+      }
+      return (await resp.json()) as HnFirebaseItem;
+    }),
+  );
+
+  for (let j = 0; j < items.length && stories.length < HN_TOP_STORIES; j += 1) {
+    const item = items[j];
+    if (!item || item.deleted || item.dead || item.type !== "story" || !item.title) continue;
+    if (!isAiRelated(item)) continue;
+    const story = toHnStory(item, i + j + 1);
+    if (acceptUniqueLink(story, dedupeState)) stories.push(story);
+  }
+}
+
+return {
+  stories,
+  fetchSuccess: stories.length > 0,
+  scannedCount,
+  duplicateCount: dedupeState.duplicateCount,
+};
+```
+
+Use `{ stories: [], fetchSuccess: false, scannedCount: 0, duplicateCount: 0 }` for top-level failures. Preserve the current per-item error log and HN discussion fallback URL.
+
+- [ ] **Step 4: Update every existing `HnData` fallback/fixture to the new required shape**
+
+In `src/index.ts` change the HN catch fallback to:
+
+```ts
+fetchHnData().catch(
+  (): HnData => ({ stories: [], fetchSuccess: false, scannedCount: 0, duplicateCount: 0 }),
+),
+```
+
+In `src/__tests__/prompt-builders.test.ts`, add `scannedCount` and `duplicateCount` to both existing `HnData` fixtures.
+
+- [ ] **Step 5: Run focused tests, type checking, and the full suite**
+
+Run:
+
+```powershell
+corepack pnpm vitest run src/__tests__/hn.test.ts src/__tests__/prompt-builders.test.ts
+corepack pnpm typecheck
+corepack pnpm test
+```
+
+Expected: all commands exit 0; the 30-link test proves scanning continues after a duplicate.
+
+- [ ] **Step 6: Commit the HN data-contract and collection change**
+
+```powershell
+git add src/hn.ts src/index.ts src/__tests__/hn.test.ts src/__tests__/prompt-builders.test.ts
+git commit -m "feat: collect thirty unique HN links"
+```
+
+### Task 4: Implement Deterministic Scoring and Stable Top 5
+
+**Files:**
+- Create: `src/radar.ts`
+- Create: `src/__tests__/radar.test.ts`
+
+**Interfaces:**
+- Consumes: `HnStory[]` and a fixed `Date`.
+- Produces: the Radar type contracts and `scoreRadarBase(stories: HnStory[], now: Date): RadarBaseItem[]` for Task 5.
+
+- [ ] **Step 1: Write failing tests for base-score boundaries and equal-value batches**
+
+Create `src/__tests__/radar.test.ts` with a `story()` fixture and these assertions:
+
+```ts
+import { describe, expect, it } from "vitest";
+import type { HnStory } from "../hn.ts";
+import { scoreRadarBase } from "../radar.ts";
+
+const NOW = new Date("2026-08-12T00:00:00.000Z");
+
+function story(id: string, overrides: Partial<HnStory> = {}): HnStory {
+  return {
+    id,
+    hnRank: Number(id),
+    title: `AI story ${id}`,
+    url: `https://example.com/${id}`,
+    hnUrl: `https://news.ycombinator.com/item?id=${id}`,
+    points: 0,
+    comments: 0,
+    author: "author",
+    createdAt: NOW.toISOString(),
+    ...overrides,
+  };
+}
+
+describe("scoreRadarBase", () => {
+  it("keeps every component inside its declared range", () => {
+    const scored = scoreRadarBase(
+      [
+        story("1", { points: 0, comments: 0, hnRank: 1, createdAt: NOW.toISOString() }),
+        story("2", { points: 10_000, comments: 5_000, hnRank: 500, createdAt: "2026-08-09T00:00:00.000Z" }),
+      ],
+      NOW,
+    );
+    for (const item of scored) {
+      expect(item.breakdown.points).toBeGreaterThanOrEqual(0);
+      expect(item.breakdown.points).toBeLessThanOrEqual(25);
+      expect(item.breakdown.comments).toBeGreaterThanOrEqual(0);
+      expect(item.breakdown.comments).toBeLessThanOrEqual(10);
+      expect(item.breakdown.rank).toBeGreaterThanOrEqual(0);
+      expect(item.breakdown.rank).toBeLessThanOrEqual(20);
+      expect(item.breakdown.freshness).toBeGreaterThanOrEqual(0);
+      expect(item.breakdown.freshness).toBeLessThanOrEqual(15);
+      expect(item.baseScore).toBeGreaterThanOrEqual(0);
+      expect(item.baseScore).toBeLessThanOrEqual(70);
+    }
+  });
+
+  it("gives equal non-zero batch values equal full popularity components", () => {
+    const scored = scoreRadarBase(
+      [story("1", { points: 100, comments: 20 }), story("2", { points: 100, comments: 20 })],
+      NOW,
+    );
+    expect(scored.map((item) => item.breakdown.points)).toEqual([25, 25]);
+    expect(scored.map((item) => item.breakdown.comments)).toEqual([10, 10]);
+  });
+});
+```
+
+- [ ] **Step 2: Run the focused test and verify the missing-module failure**
+
+Run:
+
+```powershell
+corepack pnpm vitest run src/__tests__/radar.test.ts
+```
+
+Expected: FAIL because `../radar.ts` does not exist.
+
+- [ ] **Step 3: Define Radar contracts and implement deterministic base scoring**
+
+Create `src/radar.ts` with these public types:
+
+```ts
+import type { HnData, HnStory } from "./hn.ts";
+import type { Lang } from "./i18n.ts";
+
+export interface RadarScoreBreakdown {
+  points: number;
+  comments: number;
+  rank: number;
+  freshness: number;
+}
+
+export interface RadarBaseItem {
+  story: HnStory;
+  breakdown: RadarScoreBreakdown;
+  baseScore: number;
+}
+
+export interface RadarEditorialItem {
+  id: string;
+  relevance: number;
+  novelty: number;
+  actionability: number;
+  summary: Record<Lang, string>;
+  reason: Record<Lang, string>;
+}
+
+export interface RadarItem extends RadarBaseItem {
+  editorialScore: number;
+  totalScore: number;
+  summary: Record<Lang, string>;
+  reason: Record<Lang, string>;
+}
+
+export interface RadarData {
+  items: RadarItem[];
+  top5: RadarItem[];
+  mode: "deepseek" | "deterministic";
+  scannedCount: number;
+  duplicateCount: number;
+}
+```
+
+Implement these exact formulas, retaining full floating-point precision:
+
+```ts
+const clamp = (value: number, min: number, max: number): number => Math.min(max, Math.max(min, value));
+
+function logBatchScore(value: number, values: number[], weight: number): number {
+  const logs = values.map((entry) => Math.log1p(Math.max(0, entry)));
+  const current = Math.log1p(Math.max(0, value));
+  const min = Math.min(...logs);
+  const max = Math.max(...logs);
+  if (max === min) return max === 0 ? 0 : weight;
+  return ((current - min) / (max - min)) * weight;
+}
+
+export function scoreRadarBase(stories: HnStory[], now: Date): RadarBaseItem[] {
+  if (stories.length === 0) return [];
+  const points = stories.map((story) => story.points);
+  const comments = stories.map((story) => story.comments);
+  return stories.map((story) => {
+    const rank = clamp(story.hnRank ?? 500, 1, 500);
+    const ageHours = Math.max(0, (now.getTime() - new Date(story.createdAt).getTime()) / 3_600_000);
+    const breakdown = {
+      points: logBatchScore(story.points, points, 25),
+      comments: logBatchScore(story.comments, comments, 10),
+      rank: 20 * (1 - (rank - 1) / 499),
+      freshness: 15 * (1 - clamp(ageHours, 0, 48) / 48),
+    };
+    return {
+      story,
+      breakdown,
+      baseScore: breakdown.points + breakdown.comments + breakdown.rank + breakdown.freshness,
+    };
+  });
+}
+```
+
+- [ ] **Step 4: Run base-scoring tests and type checking**
+
+Run:
+
+```powershell
+corepack pnpm vitest run src/__tests__/radar.test.ts
+corepack pnpm typecheck
+```
+
+Expected: the two base-score tests pass and TypeScript exits 0.
+
+- [ ] **Step 5: Commit the independently verified deterministic base scorer**
+
+```powershell
+git add src/radar.ts src/__tests__/radar.test.ts
+git commit -m "feat: add deterministic radar scoring"
+```
+
+### Task 5: Validate DeepSeek Editorial Scores and Guarantee Deterministic Fallback
+
+**Files:**
+- Modify: `src/radar.ts`
+- Modify: `src/__tests__/radar.test.ts`
+- Modify: `src/prompts-data.ts`
+- Modify: `src/__tests__/prompt-builders.test.ts`
+
+**Interfaces:**
+- Consumes: Task 4 base scores and an unknown parsed JSON value produced from one LLM request.
+- Produces: `validateRadarEditorial(value: unknown, candidateIds: string[]): RadarEditorialItem[]` and `generateRadarData(hnData: HnData, now: Date, loadEditorial: () => Promise<unknown>): Promise<RadarData>` in either `deepseek` or `deterministic` mode.
+
+- [ ] **Step 1: Add failing tests for valid editorial merging, invalid structures, fallback, and ties**
+
+Add `generateRadarData` to the existing import, then append to `src/__tests__/radar.test.ts`:
+
+```ts
+const editorial = (ids: string[]) => ({
+  items: ids.map((id) => ({
+    id,
+    relevance: 10,
+    novelty: 8,
+    actionability: 7,
+    summary: { zh: `摘要 ${id}`, en: `Summary ${id}` },
+    reason: { zh: `理由 ${id}`, en: `Reason ${id}` },
+  })),
+});
+
+describe("generateRadarData", () => {
+  it("merges one valid editorial record per candidate and selects five unique items", async () => {
+    const stories = Array.from({ length: 6 }, (_, index) => story(String(index + 1), { points: 60 - index }));
+    const result = await generateRadarData(
+      { stories, fetchSuccess: true, scannedCount: 8, duplicateCount: 2 },
+      NOW,
+      async () => editorial(stories.map((item) => item.id)),
+    );
+    expect(result.mode).toBe("deepseek");
+    expect(result.top5).toHaveLength(5);
+    expect(new Set(result.top5.map((item) => item.story.id)).size).toBe(5);
+    expect(result.items.every((item) => item.editorialScore === 25)).toBe(true);
+  });
+
+  const validTwo = editorial(["1", "2"]);
+  const invalidEditorialPayloads = [
+    {
+      name: "out-of-range score",
+      payload: {
+        items: validTwo.items.map((item, index) =>
+          index === 0 ? { ...item, relevance: 11 } : item,
+        ),
+      },
+    },
+    {
+      name: "unknown ID",
+      payload: {
+        items: validTwo.items.map((item, index) =>
+          index === 0 ? { ...item, id: "unknown" } : item,
+        ),
+      },
+    },
+    {
+      name: "missing ID",
+      payload: { items: validTwo.items.slice(0, 1) },
+    },
+  ];
+
+  it.each(invalidEditorialPayloads)("falls back for $name", async ({ payload }) => {
+    const stories = [story("1"), story("2")];
+    const result = await generateRadarData(
+      { stories, fetchSuccess: true, scannedCount: 2, duplicateCount: 0 },
+      NOW,
+      async () => payload,
+    );
+    expect(result.mode).toBe("deterministic");
+    expect(result.items.every((item) => item.editorialScore === 0)).toBe(true);
+    expect(result.items.every((item) => item.totalScore === (item.baseScore / 70) * 100)).toBe(true);
+  });
+
+  it("falls back when JSON parsing is represented by a rejected loader", async () => {
+    const stories = Array.from({ length: 6 }, (_, index) => story(String(index + 1), { hnRank: 5 }));
+    const result = await generateRadarData(
+      { stories, fetchSuccess: true, scannedCount: 6, duplicateCount: 0 },
+      NOW,
+      async () => Promise.reject(new SyntaxError("invalid JSON")),
+    );
+    expect(result.mode).toBe("deterministic");
+    expect(result.top5.map((item) => item.story.id)).toEqual(["1", "2", "3", "4", "5"]);
+  });
+});
+```
+
+- [ ] **Step 2: Add a failing bilingual Radar Prompt contract test**
+
+In `src/__tests__/prompt-builders.test.ts`, import `buildRadarPrompt` and add:
+
+```ts
+describe("buildRadarPrompt", () => {
+  it("includes every stable candidate ID and the exact bilingual JSON fields", () => {
+    const stories = [
+      {
+        id: "123",
+        hnRank: 4,
+        title: "AI News",
+        url: "https://example.com/ai",
+        hnUrl: "https://news.ycombinator.com/item?id=123",
+        points: 200,
+        comments: 50,
+        author: "bob",
+        createdAt: "2026-08-11T10:00:00.000Z",
+      },
+    ];
+    const prompt = buildRadarPrompt(stories, "2026-08-12");
+    expect(prompt).toContain('"id": "123"');
+    expect(prompt).toContain('"relevance"');
+    expect(prompt).toContain('"novelty"');
+    expect(prompt).toContain('"actionability"');
+    expect(prompt).toContain('"summary": { "zh"');
+    expect(prompt).toContain('"reason": { "zh"');
+    expect(prompt).toContain("Do not change IDs, URLs, points, or comments");
+  });
+});
+```
+
+- [ ] **Step 3: Run both focused tests and verify validation/prompt failures**
+
+Run:
+
+```powershell
+corepack pnpm vitest run src/__tests__/radar.test.ts src/__tests__/prompt-builders.test.ts
+```
+
+Expected: FAIL because editorial validation, fallback, stable ranking, and `buildRadarPrompt` are not implemented.
+
+- [ ] **Step 4: Implement strict all-candidate validation and stable ranking in `src/radar.ts`**
+
+Implement the complete validator first, then stable ranking and fallback:
+
+```ts
+function requireRecord(value: unknown, label: string): Record<string, unknown> {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    throw new Error(`${label} must be an object`);
+  }
+  return value as Record<string, unknown>;
+}
+
+function requireScore(value: unknown, label: string): number {
+  if (typeof value !== "number" || !Number.isInteger(value) || value < 0 || value > 10) {
+    throw new Error(`${label} must be an integer from 0 to 10`);
+  }
+  return value;
+}
+
+function requireText(value: unknown, label: string): string {
+  if (typeof value !== "string" || value.trim().length === 0) {
+    throw new Error(`${label} must be a non-empty string`);
+  }
+  return value.trim();
+}
+
+function requireLocalized(value: unknown, label: string): Record<Lang, string> {
+  const record = requireRecord(value, label);
+  return {
+    zh: requireText(record["zh"], `${label}.zh`),
+    en: requireText(record["en"], `${label}.en`),
+  };
+}
+
+export function validateRadarEditorial(
+  value: unknown,
+  candidateIds: string[],
+): RadarEditorialItem[] {
+  const root = requireRecord(value, "editorial payload");
+  if (!Array.isArray(root["items"])) throw new Error("editorial payload.items must be an array");
+  if (root["items"].length !== candidateIds.length) {
+    throw new Error("editorial payload must contain exactly one item per candidate");
+  }
+
+  const expected = new Set(candidateIds);
+  const seen = new Set<string>();
+  const items = root["items"].map((value, index): RadarEditorialItem => {
+    const item = requireRecord(value, `items[${index}]`);
+    const id = requireText(item["id"], `items[${index}].id`);
+    if (!expected.has(id)) throw new Error(`unknown candidate id: ${id}`);
+    if (seen.has(id)) throw new Error(`duplicate candidate id: ${id}`);
+    seen.add(id);
+    return {
+      id,
+      relevance: requireScore(item["relevance"], `items[${index}].relevance`),
+      novelty: requireScore(item["novelty"], `items[${index}].novelty`),
+      actionability: requireScore(item["actionability"], `items[${index}].actionability`),
+      summary: requireLocalized(item["summary"], `items[${index}].summary`),
+      reason: requireLocalized(item["reason"], `items[${index}].reason`),
+    };
+  });
+
+  if (seen.size !== expected.size) throw new Error("editorial payload is missing candidate IDs");
+  return items;
+}
+
+function compareRadarItems(a: RadarItem, b: RadarItem): number {
+  return (
+    b.totalScore - a.totalScore ||
+    (a.story.hnRank ?? Number.POSITIVE_INFINITY) - (b.story.hnRank ?? Number.POSITIVE_INFINITY) ||
+    a.story.id.localeCompare(b.story.id, "en", { numeric: true })
+  );
+}
+
+function fallbackText(story: HnStory): { summary: Record<Lang, string>; reason: Record<Lang, string> } {
+  return {
+    summary: {
+      zh: `HN 热门条目：${story.title}（${story.points} 分，${story.comments} 条评论）。`,
+      en: `HN item: ${story.title} (${story.points} points, ${story.comments} comments).`,
+    },
+    reason: {
+      zh: "基于 HN 排名、热度、讨论度与时效性的确定性推荐。",
+      en: "Deterministic recommendation based on HN rank, popularity, discussion, and freshness.",
+    },
+  };
+}
+
+export async function generateRadarData(
+  hnData: HnData,
+  now: Date,
+  loadEditorial: () => Promise<unknown>,
+): Promise<RadarData> {
+  const baseItems = scoreRadarBase(hnData.stories, now);
+  if (baseItems.length === 0) {
+    return {
+      items: [],
+      top5: [],
+      mode: "deterministic",
+      scannedCount: hnData.scannedCount,
+      duplicateCount: hnData.duplicateCount,
+    };
+  }
+  let mode: RadarData["mode"] = "deepseek";
+  let editorialById = new Map<string, RadarEditorialItem>();
+  try {
+    const validated = validateRadarEditorial(
+      await loadEditorial(),
+      hnData.stories.map((story) => story.id),
+    );
+    editorialById = new Map(validated.map((item) => [item.id, item]));
+  } catch (error) {
+    mode = "deterministic";
+    console.error(`  [radar] Editorial scoring failed; using deterministic fallback: ${error}`);
+  }
+
+  const items = baseItems
+    .map((base): RadarItem => {
+      const editorialItem = editorialById.get(base.story.id);
+      if (!editorialItem) {
+        const text = fallbackText(base.story);
+        return {
+          ...base,
+          editorialScore: 0,
+          totalScore: (base.baseScore / 70) * 100,
+          ...text,
+        };
+      }
+      const editorialScore =
+        editorialItem.relevance + editorialItem.novelty + editorialItem.actionability;
+      return {
+        ...base,
+        editorialScore,
+        totalScore: base.baseScore + editorialScore,
+        summary: editorialItem.summary,
+        reason: editorialItem.reason,
+      };
+    })
+    .sort(compareRadarItems);
+
+  return {
+    items,
+    top5: items.slice(0, 5),
+    mode,
+    scannedCount: hnData.scannedCount,
+    duplicateCount: hnData.duplicateCount,
+  };
+}
+```
+
+Expected: the validator rejects the complete payload if even one expected ID is missing, duplicated, unknown, out of range, non-integer, or lacks any bilingual text field.
+
+- [ ] **Step 5: Implement the one-request bilingual Radar Prompt**
+
+In `src/prompts-data.ts`, import `HnStory` and export:
+
+```ts
+export function buildRadarPrompt(stories: HnStory[], dateStr: string): string {
+  const candidates = stories.map((story) => ({
+    id: story.id,
+    hnRank: story.hnRank,
+    title: story.title,
+    url: story.url,
+    hnUrl: story.hnUrl,
+    points: story.points,
+    comments: story.comments,
+    createdAt: story.createdAt,
+  }));
+  return `You are the bilingual editor for an AI information radar dated ${dateStr}.
+Score every candidate exactly once. Relevance, novelty, and actionability must each be integers from 0 to 10.
+Write one concise Chinese and English summary and recommendation reason per item.
+Do not change IDs, URLs, points, or comments. Do not add or omit candidates.
+
+Candidates:
+${JSON.stringify(candidates, null, 2)}
+
+Return JSON only with this exact shape:
+{
+  "items": [
+    {
+      "id": "123",
+      "relevance": 0,
+      "novelty": 0,
+      "actionability": 0,
+      "summary": { "zh": "中文摘要", "en": "English summary" },
+      "reason": { "zh": "中文推荐理由", "en": "English recommendation reason" }
+    }
+  ]
+}`;
+}
+```
+
+- [ ] **Step 6: Run focused tests, type checking, and full regression tests**
+
+Run:
+
+```powershell
+corepack pnpm vitest run src/__tests__/radar.test.ts src/__tests__/prompt-builders.test.ts
+corepack pnpm typecheck
+corepack pnpm test
+```
+
+Expected: all commands exit 0, including invalid payload and rejected-loader fallback cases.
+
+- [ ] **Step 7: Commit scoring, editorial validation, and prompt generation together**
+
+```powershell
+git add src/radar.ts src/prompts-data.ts src/__tests__/radar.test.ts src/__tests__/prompt-builders.test.ts
+git commit -m "feat: score and rank radar candidates"
+```
+
+### Task 6: Build and Save Bilingual Radar Reports
+
+**Files:**
+- Modify: `src/i18n.ts`
+- Modify: `src/report-builders.ts`
+- Modify: `src/report-savers.ts`
+- Modify: `src/__tests__/report-builders.test.ts`
+- Modify: `src/__tests__/i18n.test.ts`
+
+**Interfaces:**
+- Consumes: `RadarData`, `utcStr`, `dateStr`, footer, and `Lang`.
+- Produces: `buildRadarReportContent(data, utcStr, dateStr, footer, lang): string` and `saveRadarReport(data, utcStr, dateStr, digestRepo, footer, lang): Promise<void>`.
+
+- [ ] **Step 1: Write failing report-builder tests for the full contract**
+
+Add `buildRadarReportContent` to the existing import from `../report-builders.ts`, add `import type { RadarData } from "../radar.ts";`, then insert this fixture and test block:
+
+```ts
+function makeRadarData(count: number, mode: RadarData["mode"]): RadarData {
+  const items: RadarData["items"] = Array.from({ length: count }, (_, index) => ({
+    story: {
+      id: String(index + 1),
+      hnRank: index + 1,
+      title: `AI story ${index + 1}`,
+      url: `https://example.com/${index + 1}`,
+      hnUrl: `https://news.ycombinator.com/item?id=${index + 1}`,
+      points: 100 - index,
+      comments: 20 - index,
+      author: "author",
+      createdAt: "2026-08-11T00:00:00.000Z",
+    },
+    breakdown: { points: 20, comments: 8, rank: 19, freshness: 10 },
+    baseScore: 57,
+    editorialScore: mode === "deepseek" ? 25 : 0,
+    totalScore: 95 - index,
+    summary: { zh: `摘要 ${index + 1}`, en: `Summary ${index + 1}` },
+    reason: { zh: `理由 ${index + 1}`, en: `Reason ${index + 1}` },
+  }));
+  return {
+    items,
+    top5: items.slice(0, 5),
+    mode,
+    scannedCount: count + 2,
+    duplicateCount: 2,
+  };
+}
+
+describe("buildRadarReportContent", () => {
+  it("renders metadata, exactly five recommendations, and every candidate in Chinese", () => {
+    const data = makeRadarData(6, "deepseek");
+    const result = buildRadarReportContent(data, "2026-08-12 00:00", "2026-08-12", "\nfooter", "zh");
+    expect(result).toContain("# AI 信息雷达 2026-08-12");
+    expect(result).toContain("扫描 8 条");
+    expect(result).toContain("候选 6 条");
+    expect(result).toContain("去重 2 条");
+    expect(result).toContain("DeepSeek 编辑评分");
+    expect((result.match(/^### \d+\./gm) ?? [])).toHaveLength(5);
+    expect((result.match(/^\| \d+ \|/gm) ?? [])).toHaveLength(6);
+    expect(new Set(data.top5.map((item) => item.story.url)).size).toBe(5);
+    for (const item of data.top5) {
+      expect(result.split(item.story.url)).toHaveLength(3);
+    }
+  });
+
+  it("marks deterministic mode and renders all available items when fewer than five exist", () => {
+    const data = makeRadarData(3, "deterministic");
+    const result = buildRadarReportContent(data, "2026-08-12 00:00", "2026-08-12", "", "en");
+    expect(result).toContain("# AI Information Radar 2026-08-12");
+    expect(result).toContain("Deterministic fallback");
+    expect(result).toContain("Only 3 candidates were available");
+    expect((result.match(/^### \d+\./gm) ?? [])).toHaveLength(3);
+  });
+});
+```
+
+- [ ] **Step 2: Add failing i18n assertions for titles, Issue labels, manifest labels, and notifications**
+
+Import `RADAR_REPORT` and assert:
+
+```ts
+expect(RADAR_REPORT.title.zh).toBe("AI 信息雷达");
+expect(RADAR_REPORT.title.en).toBe("AI Information Radar");
+expect(ISSUE_LABELS.radar.zh).toBe("radar");
+expect(ISSUE_LABELS.radar.en).toBe("radar-en");
+expect(REPORT_LABELS["ai-radar"]).toBe("AI 信息雷达");
+expect(REPORT_LABELS["ai-radar-en"]).toBe("AI Information Radar");
+expect(NOTIFY_LABELS["ai-radar"]?.zh).toBe("Top 5 信息雷达");
+```
+
+- [ ] **Step 3: Run focused tests and verify missing exports/labels**
+
+Run:
+
+```powershell
+corepack pnpm vitest run src/__tests__/report-builders.test.ts src/__tests__/i18n.test.ts
+```
+
+Expected: FAIL because Radar i18n and report builder are absent.
+
+- [ ] **Step 4: Add centralized Radar strings and discovery labels**
+
+In `src/i18n.ts`, add the complete Radar copy object next to `HN_REPORT`:
+
+```ts
+export const RADAR_REPORT = {
+  title: t("AI 信息雷达", "AI Information Radar"),
+  source: t("数据来源: Hacker News Top Stories", "Source: Hacker News Top Stories"),
+  mode: {
+    deepseek: t("DeepSeek 编辑评分", "DeepSeek editorial scoring"),
+    deterministic: t("确定性降级模式", "Deterministic fallback"),
+  },
+  meta: (
+    scanned: number,
+    candidates: number,
+    duplicates: number,
+    mode: string,
+    utcStr: string,
+    lang: Lang,
+  ) =>
+    lang === "en"
+      ? `> Source: Hacker News Top Stories | Scanned ${scanned} | Candidates ${candidates} | Duplicates ${duplicates} | Scoring: ${mode} | Generated: ${utcStr} UTC`
+      : `> 数据来源: Hacker News Top Stories | 扫描 ${scanned} 条 | 候选 ${candidates} 条 | 去重 ${duplicates} 条 | 评分模式: ${mode} | 生成时间: ${utcStr} UTC`,
+  top5: t("今日 Top 5", "Today's Top 5"),
+  allCandidates: t("全部候选", "All Candidates"),
+  reason: t("推荐理由", "Why it is recommended"),
+  discussion: t("HN 讨论", "HN discussion"),
+  tableHeader: t(
+    "| 排名 | 标题 | 总分 | Points | Comments | 发布时间 | 摘要 |",
+    "| Rank | Title | Score | Points | Comments | Published | Summary |",
+  ),
+  tableAlign: "| ---: | :--- | ---: | ---: | ---: | :--- | :--- |",
+  insufficient: (count: number, lang: Lang) =>
+    lang === "en"
+      ? `Only ${count} candidates were available; no duplicate items were added.`
+      : `当前仅有 ${count} 条候选，未使用重复条目补齐。`,
+  issueTitle: (dateStr: string, lang: Lang) =>
+    lang === "en" ? `📡 AI Information Radar ${dateStr}` : `📡 AI 信息雷达 ${dateStr}`,
+} as const;
+```
+
+Add:
+
+```ts
+radar: t("radar", "radar-en"),
+```
+
+to `ISSUE_LABELS`, add `ai-radar`/`ai-radar-en` to `REPORT_LABELS`, and add:
+
+```ts
+"ai-radar": t("Top 5 信息雷达", "Top 5 Radar"),
+```
+
+to `NOTIFY_LABELS`.
+
+- [ ] **Step 5: Implement pure Markdown rendering with stable row numbers and one-decimal scores**
+
+In `src/report-builders.ts`, import `RadarData` and `RADAR_REPORT`, then add:
+
+```ts
+function escapeRadarTable(value: string): string {
+  return value.replace(/\|/g, "\\|").replace(/\s+/g, " ").trim();
+}
+
+export function buildRadarReportContent(
+  data: RadarData,
+  utcStr: string,
+  dateStr: string,
+  footer: string,
+  lang: Lang = "zh",
+): string {
+  const mode = RADAR_REPORT.mode[data.mode][lang];
+  const recommendations = data.top5
+    .map(
+      (item, index) =>
+        `### ${index + 1}. [${item.story.title}](${item.story.url}) — ${item.totalScore.toFixed(1)}\n\n` +
+        `**${RADAR_REPORT.reason[lang]}:** ${item.reason[lang]}\n\n` +
+        `[${RADAR_REPORT.discussion[lang]}](${item.story.hnUrl})`,
+    )
+    .join("\n\n");
+
+  const rows = data.items
+    .map(
+      (item, index) =>
+        `| ${index + 1} | [${escapeRadarTable(item.story.title)}](${item.story.url}) | ` +
+        `${item.totalScore.toFixed(1)} | ${item.story.points} | ${item.story.comments} | ` +
+        `${escapeRadarTable(item.story.createdAt)} | ${escapeRadarTable(item.summary[lang])} |`,
+    )
+    .join("\n");
+
+  const insufficient =
+    data.items.length < 5 ? `${RADAR_REPORT.insufficient(data.items.length, lang)}\n\n` : "";
+
+  return (
+    `# ${RADAR_REPORT.title[lang]} ${dateStr}\n\n` +
+    RADAR_REPORT.meta(
+      data.scannedCount,
+      data.items.length,
+      data.duplicateCount,
+      mode,
+      utcStr,
+      lang,
+    ) +
+    `\n\n---\n\n## ${RADAR_REPORT.top5[lang]}\n\n` +
+    insufficient +
+    recommendations +
+    `\n\n---\n\n## ${RADAR_REPORT.allCandidates[lang]}\n\n` +
+    RADAR_REPORT.tableHeader[lang] +
+    "\n" +
+    RADAR_REPORT.tableAlign +
+    "\n" +
+    rows +
+    footer
+  );
+}
+```
+
+This uses original article links in titles, HN discussion links in Top 5, one-decimal display scores, every sorted candidate exactly once, and the existing footer unchanged.
+
+- [ ] **Step 6: Add the saver wrapper without another LLM request**
+
+In `src/report-savers.ts`, import `RadarData`, `buildRadarReportContent`, and `RADAR_REPORT`. Export:
+
+```ts
+export async function saveRadarReport(
+  data: RadarData,
+  utcStr: string,
+  dateStr: string,
+  digestRepo: string,
+  footer: string,
+  lang: Lang = "zh",
+): Promise<void> {
+  if (data.items.length === 0) {
+    console.log(`  [radar/${lang}] No data available, skipping report.`);
+    return;
+  }
+  const fileName = lang === "en" ? "ai-radar-en.md" : "ai-radar.md";
+  const content = buildRadarReportContent(data, utcStr, dateStr, footer, lang);
+  console.log(`  Saved ${saveFile(content, dateStr, fileName)}`);
+  if (digestRepo) {
+    const url = await createGitHubIssue(
+      RADAR_REPORT.issueTitle(dateStr, lang),
+      content,
+      ISSUE_LABELS.radar[lang],
+    );
+    console.log(`  Created Radar issue (${lang}): ${url}`);
+  }
+}
+```
+
+- [ ] **Step 7: Run focused tests, type checking, and the full suite**
+
+Run:
+
+```powershell
+corepack pnpm vitest run src/__tests__/report-builders.test.ts src/__tests__/i18n.test.ts
+corepack pnpm typecheck
+corepack pnpm test
+```
+
+Expected: all commands exit 0 and both languages render the same ranked candidate IDs.
+
+- [ ] **Step 8: Commit report rendering and saving**
+
+```powershell
+git add src/i18n.ts src/report-builders.ts src/report-savers.ts src/__tests__/report-builders.test.ts src/__tests__/i18n.test.ts
+git commit -m "feat: render bilingual radar reports"
+```
+
+### Task 7: Integrate One Radar Editorial Call into the Existing Main Flow
+
+**Files:**
+- Modify: `src/index.ts`
+- Modify: `src/__tests__/radar.test.ts`
+
+**Interfaces:**
+- Consumes: `buildRadarPrompt`, `callLlm`, `parseLlmJson`, `generateRadarData`, and `saveRadarReport`.
+- Produces: exactly one bilingual Radar editorial request per run, two local files, and `ai-radar` highlights input; failures stay isolated to deterministic Radar mode.
+
+- [ ] **Step 1: Add an orchestration-focused test proving the editorial loader runs once**
+
+In `src/__tests__/radar.test.ts`, add:
+
+```ts
+it("calls the bilingual editorial loader exactly once", async () => {
+  const stories = [story("1"), story("2")];
+  let calls = 0;
+  await generateRadarData(
+    { stories, fetchSuccess: true, scannedCount: 2, duplicateCount: 0 },
+    NOW,
+    async () => {
+      calls += 1;
+      return editorial(["1", "2"]);
+    },
+  );
+  expect(calls).toBe(1);
+});
+```
+
+- [ ] **Step 2: Run the focused test to lock the one-call contract**
+
+Run:
+
+```powershell
+corepack pnpm vitest run src/__tests__/radar.test.ts
+```
+
+Expected: PASS before integration, establishing the function contract that `index.ts` must use once rather than once per language.
+
+- [ ] **Step 3: Import the Radar pipeline and create one shared promise after fetch**
+
+In `src/index.ts`, add imports for `buildRadarPrompt`, `generateRadarData`, and `saveRadarReport`. Immediately after `fetchAllData` resolves, create:
+
+```ts
+const radarDataPromise = generateRadarData(hnData, now, async () => {
+  console.log("  [radar] Calling LLM for bilingual editorial scoring...");
+  const raw = await callLlm(buildRadarPrompt(hnData.stories, dateStr), LLM_TOKENS_LISTING);
+  return parseLlmJson<unknown>(raw);
+});
+```
+
+Also import `LLM_TOKENS_LISTING` from `report.ts`. `generateRadarData` must be called even when the LLM fails so deterministic output remains available.
+
+- [ ] **Step 4: Await Radar once and save both languages with the existing report batch**
+
+Before the report-saving `Promise.all`, await `radarDataPromise` once:
+
+```ts
+const radarData = await radarDataPromise;
+```
+
+Add both saver calls to the existing save batch:
+
+```ts
+saveRadarReport(radarData, utcStr, dateStr, digestRepo, autoGenFooter("zh"), "zh"),
+saveRadarReport(radarData, utcStr, dateStr, digestRepo, autoGenFooter("en"), "en"),
+```
+
+This preserves all current save calls and does not replace `ai-hn`.
+
+- [ ] **Step 5: Include Radar files in both highlights input maps**
+
+Add this tuple to the existing `readReport` loop:
+
+```ts
+["ai-radar", "ai-radar.md", "ai-radar-en.md"],
+```
+
+Expected: notification highlights can include Radar without changing the highlights JSON schema.
+
+- [ ] **Step 6: Run type checking and the full regression suite**
+
+Run:
+
+```powershell
+corepack pnpm typecheck
+corepack pnpm test
+```
+
+Expected: both exit 0; existing report tests remain unchanged in behavior.
+
+- [ ] **Step 7: Commit main-flow integration**
+
+```powershell
+git add src/index.ts src/__tests__/radar.test.ts
+git commit -m "feat: integrate radar into daily digest"
+```
+
+### Task 8: Register Radar in Manifest, RSS, Static Web UI, and Notifications
+
+**Files:**
+- Modify: `src/generate-manifest.ts`
+- Modify: `src/__tests__/generate-manifest.test.ts`
+- Modify: `index.html`
+- Modify: `src/__tests__/notify.test.ts`
+- Modify: `src/__tests__/feishu.test.ts`
+
+**Interfaces:**
+- Consumes: generated `ai-radar.md` / `ai-radar-en.md` and `NOTIFY_LABELS["ai-radar"]` from Task 6.
+- Produces: sidebar labels, manifest/RSS discovery, Telegram links, and Feishu links.
+
+- [ ] **Step 1: Export the report whitelist and add a failing registration test**
+
+Change the declaration to `export const REPORT_FILES: readonly string[] = [`; then in `src/__tests__/generate-manifest.test.ts` import it and add:
+
+```ts
+it("registers both Radar language files in manifest order", () => {
+  const zhIndex = REPORT_FILES.indexOf("ai-radar");
+  expect(zhIndex).toBeGreaterThan(-1);
+  expect(REPORT_FILES[zhIndex + 1]).toBe("ai-radar-en");
+});
+```
+
+Run:
+
+```powershell
+corepack pnpm vitest run src/__tests__/generate-manifest.test.ts
+```
+
+Expected: FAIL until the two Radar IDs are added to `REPORT_FILES`.
+
+- [ ] **Step 2: Register both report IDs after the existing HN pair**
+
+In `src/generate-manifest.ts`, place:
+
+```ts
+"ai-radar",
+"ai-radar-en",
+```
+
+immediately after `"ai-hn-en"`. This causes both manifest and RSS generation to pick them up without a parallel discovery path.
+
+- [ ] **Step 3: Register visible static-site labels**
+
+In the `LABELS` object in `index.html`, place:
+
+```js
+'ai-radar':       'Top 5 信息雷达',
+'ai-radar-en':    'Top 5 Radar',
+```
+
+immediately after the HN labels. No route or rendering code change is needed because the site already loads IDs from `manifest.json`.
+
+- [ ] **Step 4: Add Telegram and Feishu link assertions**
+
+In `src/__tests__/notify.test.ts`, add:
+
+```ts
+it("renders Radar bilingual links", () => {
+  const msg = buildMessage("2026-08-12", ["ai-radar", "ai-radar-en"], BASE_URL);
+  expect(msg).toContain("Top 5 信息雷达");
+  expect(msg).toContain("#2026-08-12/ai-radar-en");
+});
+```
+
+In `src/__tests__/feishu.test.ts`, add the equivalent test using `buildFeishuMessage` and the same two assertions.
+
+- [ ] **Step 5: Run discovery and notification regression tests**
+
+Run:
+
+```powershell
+corepack pnpm vitest run src/__tests__/generate-manifest.test.ts src/__tests__/notify.test.ts src/__tests__/feishu.test.ts src/__tests__/i18n.test.ts
+corepack pnpm typecheck
+```
+
+Expected: all commands exit 0.
+
+- [ ] **Step 6: Commit all discovery surfaces together**
+
+```powershell
+git add src/generate-manifest.ts src/__tests__/generate-manifest.test.ts index.html src/__tests__/notify.test.ts src/__tests__/feishu.test.ts
+git commit -m "feat: publish radar across discovery surfaces"
+```
+
+### Task 9: Document DeepSeek Local Use and Perform Final Verification
+
+**Files:**
+- Modify: `.env.example`
+- Modify: `README.md`
+- Verify: all source and test files changed in Tasks 2–8
+- Runtime output only: `digests/2026-08-12/ai-radar.md`
+- Runtime output only: `digests/2026-08-12/ai-radar-en.md`
+
+**Interfaces:**
+- Consumes: complete Radar pipeline and the valid local credentials established in Task 1.
+- Produces: newcomer-safe setup documentation and fresh proof of 30 unique candidates / 5 unique recommendations in both normal and simulated-failure paths.
+
+- [ ] **Step 1: Update the environment example without a live secret**
+
+Replace `.env.example` with:
+
+```dotenv
+# Choose one LLM provider and set only its required key.
+LLM_PROVIDER=deepseek
+DEEPSEEK_API_KEY=sk-xxxxx
+
+# Alternative providers:
+# LLM_PROVIDER=anthropic
+# ANTHROPIC_API_KEY=sk-ant-xxxxx
+# LLM_PROVIDER=openai
+# OPENAI_API_KEY=sk-xxxxx
+```
+
+- [ ] **Step 2: Add DeepSeek and safe Windows local-run instructions to README**
+
+Update the provider tables to include `deepseek`, `DEEPSEEK_API_KEY`, and default model `deepseek-v4-flash`. In “Running locally”, add a PowerShell example using:
+
+```powershell
+corepack pnpm install --frozen-lockfile
+$env:GITHUB_TOKEN = gh auth token
+Remove-Item Env:DIGEST_REPO -ErrorAction SilentlyContinue
+node --env-file=.env --import=tsx src/index.ts
+```
+
+Document that `.env` contains the DeepSeek provider/key only, `GITHUB_TOKEN` stays process-local, omitting `DIGEST_REPO` prevents Issue creation, and the new outputs are `ai-radar.md` / `ai-radar-en.md` with up to 30 unique candidates and Top 5 recommendations.
+
+- [ ] **Step 3: Run formatting, lint, type checking, and all tests from a fresh command prompt**
+
+Run:
+
+```powershell
+corepack pnpm format
+corepack pnpm format:check
+corepack pnpm lint
+corepack pnpm typecheck
+corepack pnpm test
+```
+
+Expected: every command exits 0. Review `git diff` after formatting so only intended files changed.
+
+- [ ] **Step 4: Run the full application once with DeepSeek and publishing disabled**
+
+Run in one PowerShell process:
+
+```powershell
+$env:GITHUB_TOKEN = gh auth token
+Remove-Item Env:DIGEST_REPO -ErrorAction SilentlyContinue
+node --env-file=.env --import=tsx src/index.ts
+```
+
+Expected: exit code 0; `digests/2026-08-12/ai-radar.md` and `ai-radar-en.md` exist; mode is DeepSeek unless the external service actually fails; no Issue creation log appears.
+
+- [ ] **Step 5: Verify real report invariants without relying on visual inspection alone**
+
+Run:
+
+```powershell
+Select-String -Path 'digests\2026-08-12\ai-radar.md' -Pattern '^### [1-5]\.'
+Select-String -Path 'digests\2026-08-12\ai-radar.md' -Pattern '^\| [0-9]+ \|'
+Select-String -Path 'digests\2026-08-12\ai-radar-en.md' -Pattern '^### [1-5]\.'
+```
+
+Expected when HN supplies enough AI stories: five Top headings and thirty candidate table rows in Chinese, five Top headings in English. Manually compare the linked URLs in Top 5 against the candidate table and confirm all five are unique. If HN supplies fewer than 30, accept the actual unique count only when the metadata reports the same count.
+
+- [ ] **Step 6: Prove the deterministic fallback with the automated failure-path test**
+
+Run:
+
+```powershell
+corepack pnpm vitest run src/__tests__/radar.test.ts -t "falls back when JSON parsing is represented by a rejected loader"
+```
+
+Expected: PASS with stable IDs `1` through `5` and no network call.
+
+- [ ] **Step 7: Audit secrets, generated artifacts, and source diff before committing docs**
+
+Run:
+
+```powershell
+git status --short
+git diff --check
+git diff --stat
+git grep -n -E 'sk-[A-Za-z0-9_-]{12,}|github_pat_[A-Za-z0-9_]{12,}|gh[pousr]_[A-Za-z0-9]{12,}' -- ':!pnpm-lock.yaml'
+```
+
+Expected: `git diff --check` exits 0; secret scan returns no live credential; generated digest/state files remain unstaged and are excluded from the feature commit.
+
+- [ ] **Step 8: Commit documentation only after all verification evidence is fresh**
+
+```powershell
+git add .env.example README.md
+git commit -m "docs: explain DeepSeek radar setup"
+```
+
+- [ ] **Step 9: Perform final branch verification and request code review**
+
+Run:
+
+```powershell
+corepack pnpm format:check
+corepack pnpm lint
+corepack pnpm typecheck
+corepack pnpm test
+git status --short --branch
+```
+
+Expected: all quality gates exit 0. Generated local reports may remain unstaged for user inspection; source, test, and documentation changes are committed. Invoke `superpowers:requesting-code-review`, fix only evidence-backed findings, rerun this verification, then invoke `superpowers:finishing-a-development-branch` for the handoff decision.

--- a/docs/superpowers/specs/2026-08-12-agents-radar-reproduction-design.md
+++ b/docs/superpowers/specs/2026-08-12-agents-radar-reproduction-design.md
@@ -1,0 +1,166 @@
+# agents-radar 原版复现与 Top 5 信息雷达设计
+
+日期：2026-08-12
+
+## 背景与结论
+
+`agents-radar` 是一个由 GitHub Actions 定时触发的 TypeScript 资讯流水线。它从 GitHub、Hacker News、Product Hunt、ArXiv、Hugging Face、Dev.to、Lobste.rs，以及 Anthropic/OpenAI 官网抓取数据，调用 LLM 生成中英双语 Markdown 日报，并可发布为 GitHub Issues、GitHub Pages 和 RSS。
+
+本次工作采用“先验证上游原版，再做最小原生扩展”的路线。原版必须先在本机真实跑通；只有确认因账号、网络、模型或服务限制无法运行时，才启用保真降级。扩展不替换现有日报，而是新增一个聚焦 Hacker News 的 `ai-radar` 报告，实现每日 30 条唯一链接、可解释评分和固定 Top 5 推荐。
+
+## 目标
+
+1. 在 Windows 本机按上游依赖和入口运行完整原版，不先重写抓取、LLM 或报告流程。
+2. 使用 DeepSeek 作为 LLM Provider，并使用有效的 GitHub Token 读取公开仓库数据。
+3. 基线运行只写本地文件，不创建 GitHub Issues 或推送提交。
+4. 原版通过后，新增中英双语 `ai-radar.md` / `ai-radar-en.md`：
+   - 从 Hacker News Top Stories 扫描并尽量取得 30 条唯一 AI 链接；
+   - 规范化 URL 与标题并去重，遇到重复时继续扫描以补足 30 条；
+   - 为每条链接计算 0–100 的可解释分数；
+   - 固定输出 5 条最高分推荐和全部候选的评分表；
+   - DeepSeek 不可用或返回非法结构时，仍生成确定性 Top 5。
+5. 保持上游的模块边界、双语约定、错误处理风格和测试工具链。
+
+## 非目标
+
+- 不引入数据库、Docker、浏览器自动化或本地模型。
+- 不在第一版建立用户画像、邮件订阅、管理后台或多用户系统。
+- 不把所有十类来源强行混入统一评分；第一版使用上游已经稳定产出 30 条的 Hacker News 流程，待核心闭环验证后再扩展来源。
+- 不改变现有日报的文件名、输出结构或发布行为。
+- 不在基线阶段提交自动生成的日报文件。
+
+## 实施阶段
+
+### 阶段 1：原版基线复现
+
+1. 修复 GitHub CLI 登录，但不在命令输出中显示 Token。
+2. 使用项目声明的 `pnpm@9.15.9` 和 frozen lockfile 安装依赖。
+3. 先使用本机已有 Node.js 24；只有出现可归因于 Node 版本的问题时才切换到上游 CI 使用的 Node.js 22。
+4. 依次执行格式检查、lint、类型检查和单元测试。
+5. 将 `GITHUB_TOKEN` 仅注入当前进程；DeepSeek Key 由用户写入 Git 已忽略的 `.env`，通过 Node 的 `--env-file` 加载。
+6. 不设置 `DIGEST_REPO`，因此原版运行只生成 `digests/YYYY-MM-DD/` 文件，不创建 Issues。
+7. 保存运行日志和 `git diff` 摘要，确认没有密钥泄漏，且变化仅来自预期的日报和状态文件。
+
+基线成功标准：依赖安装和质量检查通过，`pnpm start` 等价入口退出码为 0，至少生成核心 CLI、Agents、Infra 和 HN 报告；HN 报告显示实际抓取数量并保留原文链接。
+
+### 阶段 2：Top 5 信息雷达扩展
+
+新增一个独立、可测试的数据处理层，不把评分逻辑塞进 `src/index.ts`：
+
+- `src/link-utils.ts`：URL 规范化、标题规范化和去重键生成。
+- `src/radar.ts`：候选模型、确定性评分、DeepSeek 评分合并、稳定排序与 Top 5 选择。
+- `src/prompts-data.ts`：新增一次性返回结构化双语评分数据的 Radar Prompt。
+- `src/report-savers.ts`：新增 Radar 中英双语报告保存函数。
+- `src/index.ts`：在 HN 数据获取后调用 Radar 流程，并将两种语言报告纳入 highlights。
+- `src/i18n.ts`、`src/generate-manifest.ts`、`index.html` 和 GitHub label 映射：注册 `ai-radar`，保持现有 Web UI、RSS 和双语约定。
+
+## 数据流
+
+```text
+HN Top Stories 前 500 条
+  -> AI 关键词筛选
+  -> URL/标题规范化去重
+  -> 重复时继续扫描，最多保留 30 条唯一候选
+  -> 确定性基础分（0–70）
+  -> 一次 DeepSeek 结构化编辑评分（0–30，双语）
+  -> 合成总分并稳定排序
+  -> Top 5 推荐 + 30 条评分表
+  -> ai-radar.md / ai-radar-en.md
+```
+
+若 HN 当前数据不足 30 条，报告必须显示实际数量，不伪造或复用链接。
+
+## 去重规则
+
+URL 规范化按以下顺序进行：
+
+1. 主机名转小写，移除默认端口。
+2. 移除 fragment。
+3. 移除常见跟踪参数，如 `utm_*`、`ref`、`source`、`fbclid`、`gclid`。
+4. 对查询参数按键排序。
+5. 除根路径外移除尾部 `/`。
+6. 对没有外链的 HN 帖子使用 HN discussion URL。
+
+第一去重键是规范化 URL。第二去重键是标题转小写、移除标点、折叠空白后的文本。任一键重复即视为同一候选，保留 HN 排名更高的条目。
+
+## 评分模型
+
+### 确定性基础分：0–70
+
+- HN points：0–25。对当日候选使用 `log1p` 后的批内归一化，减弱极端爆款的支配效应。
+- 评论数：0–10。使用 `log1p` 后的批内归一化。
+- HN 排名：0–20。第一名得 20 分，按候选中的原始 HN 排名线性衰减。
+- 时效：0–15。发布时间 0 小时得 15 分，48 小时及以上得 0 分，中间线性衰减。
+
+所有分项和中间值保留足够精度，最终展示分四舍五入到一位小数。
+
+### DeepSeek 编辑分：0–30
+
+一次请求评估全部候选，并为每条返回：
+
+- `relevance`：技术与 AI 相关性，0–10；
+- `novelty`：新颖性与信号价值，0–10；
+- `actionability`：对开发者/研究者的可操作价值，0–10；
+- 中英文一句话摘要；
+- 中英文推荐理由。
+
+返回值必须使用候选稳定 ID 对齐，不允许模型改写 points、comments、URL 或候选 ID。缺失、越界或未知 ID 的条目视为无效。
+
+### 降级评分
+
+若 DeepSeek 请求失败、429 重试耗尽或结构化数据无法修复：
+
+- 不终止 Radar 报告；
+- 将确定性基础分按 `基础分 / 70 * 100` 重映射为 0–100；
+- 使用标题和可用元数据生成简短的非推测性说明；
+- 在报告头部标记“确定性降级模式”；
+- 仍按稳定规则输出 5 条推荐。
+
+排序键依次为总分降序、HN 原始排名升序、候选 ID 升序，确保相同输入得到相同 Top 5。
+
+## 输出格式
+
+每种语言的 Radar 报告包含：
+
+1. 数据来源、候选数量、去重数量、评分模式和生成时间。
+2. `今日 Top 5`：排名、标题链接、总分、推荐理由、HN discussion 链接。
+3. `全部候选`：包含排名、标题、总分、points、comments、发布时间和简短摘要的 Markdown 表格。
+4. 自动生成页脚。
+
+若候选不足 5 条，则输出全部候选并明确说明数据不足；不复制条目补齐。
+
+## 错误处理
+
+- 单条 HN item 请求失败：记录 ID 和 HTTP 状态，继续处理其他条目。
+- GitHub 数据源失败：保持上游原有的按来源降级逻辑。
+- DeepSeek 429：沿用现有 5/10/20 秒指数退避和最多 3 次重试。
+- DeepSeek 非法 JSON：使用现有 `parseLlmJson` 修复一次；失败后进入确定性降级。
+- 文件写入失败：让主流程失败并返回非零退出码，不报告虚假成功。
+- 可选报告无数据：继续运行，其余报告不受影响。
+
+## 安全与凭据
+
+- `.env` 已被上游 `.gitignore` 忽略，只保存 `LLM_PROVIDER=deepseek` 和 `DEEPSEEK_API_KEY`。
+- GitHub Token 不写入 `.env`，由有效的 `gh auth token` 仅注入当前进程。
+- 任何日志、测试快照、错误信息和报告都不得包含完整或部分 API Key。
+- 基线与首轮 Radar 验证均不设置 `DIGEST_REPO`，禁止意外创建 Issues。
+- 不自动修改 GitHub Actions Secrets；如后续部署，由用户在 GitHub UI 中输入 DeepSeek Key。
+
+## 测试与验收
+
+新增单元测试覆盖：
+
+- URL 大小写、尾斜杠、fragment、跟踪参数和查询参数排序；
+- URL 重复、标题重复及保留更高 HN 排名；
+- 去重后继续补足 30 条；
+- 各评分分项的上下界、单元素批次和全相同数值；
+- DeepSeek 分数越界、未知 ID、缺失条目和非法 JSON；
+- 确定性降级仍输出稳定 Top 5；
+- 分数相同情况下的稳定排序；
+- 报告中所有 Top 5 均存在于 30 条候选表中且链接唯一。
+
+最终验收命令包括 `pnpm format:check`、`pnpm lint`、`pnpm typecheck`、`pnpm test` 和一次真实本地运行。完成标准是：在数据充足时生成 30 条唯一候选和恰好 5 条唯一推荐；在 DeepSeek 故障模拟下仍产生同结构的降级报告；原有日报测试和输出不回退。
+
+## 后续扩展边界
+
+第一版稳定后，才考虑把 GitHub Trending、Dev.to、Lobste.rs、ArXiv、Hugging Face 和 Product Hunt 纳入统一候选池。跨来源扩展必须先定义来源内百分位和来源配额，避免 points、stars、downloads 等不可直接比较的指标造成排序偏差。

--- a/index.html
+++ b/index.html
@@ -325,6 +325,8 @@ const LABELS = {
   'ai-trending-en':  'GitHub AI Trends',
   'ai-hn':           'HN 社区动态',
   'ai-hn-en':        'HN Community Digest',
+  'ai-radar':       'Top 5 信息雷达',
+  'ai-radar-en':    'Top 5 Radar',
   'ai-ph':           'Product Hunt AI',
   'ai-ph-en':        'Product Hunt AI',
   'ai-arxiv':        'ArXiv AI 研究',

--- a/src/__tests__/feishu.test.ts
+++ b/src/__tests__/feishu.test.ts
@@ -34,6 +34,12 @@ describe("buildFeishuMessage", () => {
     expect(msg).not.toContain("HN Community");
   });
 
+  it("renders Radar bilingual links", () => {
+    const msg = buildFeishuMessage("2026-08-12", ["ai-radar", "ai-radar-en"], BASE_URL);
+    expect(msg).toContain("Top 5 信息雷达");
+    expect(msg).toContain("#2026-08-12/ai-radar-en");
+  });
+
   it("includes Web UI and RSS links", () => {
     const msg = buildFeishuMessage("2026-03-09", ["ai-cli"], BASE_URL);
     expect(msg).toContain("🌐 Web UI");

--- a/src/__tests__/generate-manifest.test.ts
+++ b/src/__tests__/generate-manifest.test.ts
@@ -1,5 +1,13 @@
 import { describe, it, expect } from "vitest";
-import { toRfc822, escapeXml } from "../generate-manifest.ts";
+import { toRfc822, escapeXml, REPORT_FILES } from "../generate-manifest.ts";
+
+describe("REPORT_FILES", () => {
+  it("registers both Radar language files in manifest order", () => {
+    const zhIndex = REPORT_FILES.indexOf("ai-radar");
+    expect(zhIndex).toBeGreaterThan(-1);
+    expect(REPORT_FILES[zhIndex + 1]).toBe("ai-radar-en");
+  });
+});
 
 // ---------------------------------------------------------------------------
 // toRfc822

--- a/src/__tests__/github.test.ts
+++ b/src/__tests__/github.test.ts
@@ -1,0 +1,58 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createGitHubIssue } from "../github.ts";
+
+const originalDigestRepo = process.env["DIGEST_REPO"];
+const originalGitHubToken = process.env["GITHUB_TOKEN"];
+
+function restoreEnv(name: "DIGEST_REPO" | "GITHUB_TOKEN", value: string | undefined): void {
+  if (value === undefined) {
+    delete process.env[name];
+  } else {
+    process.env[name] = value;
+  }
+}
+
+afterEach(() => {
+  restoreEnv("DIGEST_REPO", originalDigestRepo);
+  restoreEnv("GITHUB_TOKEN", originalGitHubToken);
+  vi.unstubAllGlobals();
+});
+
+describe("createGitHubIssue", () => {
+  it.each([
+    { label: "radar", color: "0ea5e9" },
+    { label: "radar-en", color: "38bdf8" },
+  ])("creates the $label label with its assigned color before the Issue", async ({ label, color }) => {
+    process.env["DIGEST_REPO"] = "example/agents-radar";
+    process.env["GITHUB_TOKEN"] = "test-token";
+    const fetchMock = vi
+      .fn<typeof fetch>()
+      .mockResolvedValueOnce(new Response(null, { status: 201 }))
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ html_url: "https://github.com/example/agents-radar/issues/42" }), {
+          status: 201,
+          headers: { "Content-Type": "application/json" },
+        }),
+      );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const url = await createGitHubIssue("Radar 2026-08-12", "Issue body", label);
+
+    expect(url).toBe("https://github.com/example/agents-radar/issues/42");
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+
+    const [labelUrl, labelInit] = fetchMock.mock.calls[0]!;
+    expect(labelUrl).toBe("https://api.github.com/repos/example/agents-radar/labels");
+    expect(labelInit).toMatchObject({
+      method: "POST",
+      body: JSON.stringify({ name: label, color }),
+    });
+
+    const [issueUrl, issueInit] = fetchMock.mock.calls[1]!;
+    expect(issueUrl).toBe("https://api.github.com/repos/example/agents-radar/issues");
+    expect(issueInit).toMatchObject({
+      method: "POST",
+      body: JSON.stringify({ title: "Radar 2026-08-12", body: "Issue body", labels: [label] }),
+    });
+  });
+});

--- a/src/__tests__/hn.test.ts
+++ b/src/__tests__/hn.test.ts
@@ -163,4 +163,74 @@ describe("fetchHnData", () => {
     expect(result.stories.map((story) => story.id)).toEqual(["202"]);
     expect(console.error).toHaveBeenCalledWith("  [hn] item 201: HTTP 503");
   });
+
+  it("isolates a rejected item fetch and keeps successful items from the same batch", async () => {
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => undefined);
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (input) => {
+      const url = String(input);
+      if (url.endsWith("/topstories.json")) return jsonResponse([401, 402]);
+      if (url.endsWith("/item/401.json")) throw new TypeError("fetch failed: secret-token");
+      return jsonResponse({
+        id: 402,
+        type: "story",
+        title: "AI compiler",
+        url: "https://example.com/compiler",
+      });
+    });
+
+    const result = await fetchHnData();
+
+    expect(result.stories.map((story) => story.id)).toEqual(["402"]);
+    expect(result.scannedCount).toBe(2);
+    expect(errorSpy).toHaveBeenCalledWith("  [hn] item 401: request failed");
+    expect(errorSpy.mock.calls.flat().join(" ")).not.toContain("secret-token");
+  });
+
+  it("isolates a rejected item JSON body and keeps successful items from the same batch", async () => {
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => undefined);
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (input) => {
+      const url = String(input);
+      if (url.endsWith("/topstories.json")) return jsonResponse([501, 502]);
+      if (url.endsWith("/item/501.json")) {
+        return {
+          ok: true,
+          json: () => Promise.reject(new SyntaxError("invalid JSON: secret-body")),
+        } as Response;
+      }
+      return jsonResponse({
+        id: 502,
+        type: "story",
+        title: "AI inference engine",
+        url: "https://example.com/inference",
+      });
+    });
+
+    const result = await fetchHnData();
+
+    expect(result.stories.map((story) => story.id)).toEqual(["502"]);
+    expect(result.scannedCount).toBe(2);
+    expect(errorSpy).toHaveBeenCalledWith("  [hn] item 501: request failed");
+    expect(errorSpy.mock.calls.flat().join(" ")).not.toContain("secret-body");
+  });
+
+  it("logs the number of requested items rather than every available topstory", async () => {
+    const logSpy = vi.spyOn(console, "log").mockImplementation(() => undefined);
+    const ids = Array.from({ length: 60 }, (_, index) => 601 + index);
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (input) => {
+      const url = String(input);
+      if (url.endsWith("/topstories.json")) return jsonResponse(ids);
+      const id = Number(url.match(/item\/(\d+)\.json$/)?.[1]);
+      return jsonResponse({
+        id,
+        type: "story",
+        title: `AI story ${id}`,
+        url: `https://example.com/${id}`,
+      });
+    });
+
+    const result = await fetchHnData();
+
+    expect(result.scannedCount).toBe(50);
+    expect(logSpy).toHaveBeenCalledWith("  [hn] 30 AI stories (scanned 50 topstories)");
+  });
 });

--- a/src/__tests__/hn.test.ts
+++ b/src/__tests__/hn.test.ts
@@ -86,6 +86,8 @@ describe("fetchHnData", () => {
     expect(result.stories.map((story) => story.id)).toEqual(["102", "103"]);
     expect(result.stories.map((story) => story.hnRank)).toEqual([2, 3]);
     expect(result.stories.map((story) => story.points)).toEqual([100, 300]);
+    expect(result.scannedCount).toBe(4);
+    expect(result.duplicateCount).toBe(0);
   });
 
   it("returns an unsuccessful result when the topstories request fails", async () => {
@@ -93,6 +95,72 @@ describe("fetchHnData", () => {
 
     const result = await fetchHnData();
 
-    expect(result).toEqual({ stories: [], fetchSuccess: false });
+    expect(result).toEqual({ stories: [], fetchSuccess: false, scannedCount: 0, duplicateCount: 0 });
+  });
+
+  it("continues scanning until it has 30 unique AI links", async () => {
+    const ids = Array.from({ length: 32 }, (_, index) => 101 + index);
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (input) => {
+      const url = String(input);
+      if (url.endsWith("/topstories.json")) return jsonResponse(ids);
+      const id = Number(url.match(/item\/(\d+)\.json$/)?.[1]);
+      const offset = id - 101;
+      return jsonResponse({
+        id,
+        type: "story",
+        by: "author",
+        time: 1_800_000_000 + offset,
+        title: offset === 1 ? "A different AI headline" : `AI story ${offset}`,
+        score: 100 - offset,
+        descendants: offset,
+        url: offset === 1 ? "https://EXAMPLE.com/ai-0?utm_source=hn" : `https://example.com/ai-${offset}`,
+      });
+    });
+
+    const result = await fetchHnData();
+    expect(result.stories).toHaveLength(30);
+    expect(result.stories.at(-1)?.id).toBe("131");
+    expect(result.duplicateCount).toBe(1);
+    expect(result.scannedCount).toBe(32);
+  });
+
+  it("keeps the higher-ranked story when normalized titles collide", async () => {
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (input) => {
+      const url = String(input);
+      if (url.endsWith("/topstories.json")) return jsonResponse([301, 302, 303]);
+      const id = Number(url.match(/item\/(\d+)\.json$/)?.[1]);
+      const items = {
+        301: { id: 301, type: "story", title: "AI Launch!", url: "https://example.com/a" },
+        302: { id: 302, type: "story", title: "ai launch", url: "https://example.com/b" },
+        303: { id: 303, type: "story", title: "AI compiler", url: "https://example.com/c" },
+      };
+      return jsonResponse(items[id as keyof typeof items]);
+    });
+
+    const result = await fetchHnData();
+    expect(result.stories.map((story) => story.id)).toEqual(["301", "303"]);
+    expect(result.stories.map((story) => story.hnRank)).toEqual([1, 3]);
+    expect(result.duplicateCount).toBe(1);
+  });
+
+  it("logs one failed item and continues with the remaining batch", async () => {
+    vi.spyOn(console, "error").mockImplementation(() => undefined);
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (input) => {
+      const url = String(input);
+      if (url.endsWith("/topstories.json")) return jsonResponse([201, 202]);
+      if (url.endsWith("/item/201.json")) return jsonResponse({ error: "failed" }, 503);
+      return jsonResponse({
+        id: 202,
+        type: "story",
+        title: "AI compiler",
+        url: "https://example.com/compiler",
+        score: 10,
+        descendants: 2,
+      });
+    });
+
+    const result = await fetchHnData();
+    expect(result.stories.map((story) => story.id)).toEqual(["202"]);
+    expect(console.error).toHaveBeenCalledWith("  [hn] item 201: HTTP 503");
   });
 });

--- a/src/__tests__/i18n.test.ts
+++ b/src/__tests__/i18n.test.ts
@@ -6,6 +6,7 @@ import {
   WEB_REPORT,
   TRENDING_REPORT,
   HN_REPORT,
+  RADAR_REPORT,
   INFRA_REPORT,
   ISSUE_LABELS,
   CLI_ISSUE_TITLE,
@@ -143,6 +144,16 @@ describe("REPORT_LABELS", () => {
   it("covers the infra report in both languages", () => {
     expect(REPORT_LABELS["ai-infra"]).toBe("AI 基础设施日报");
     expect(REPORT_LABELS["ai-infra-en"]).toBe("AI Infrastructure Digest");
+  });
+
+  it("covers Radar titles, Issue labels, manifest labels, and notifications", () => {
+    expect(RADAR_REPORT.title.zh).toBe("AI 信息雷达");
+    expect(RADAR_REPORT.title.en).toBe("AI Information Radar");
+    expect(ISSUE_LABELS.radar.zh).toBe("radar");
+    expect(ISSUE_LABELS.radar.en).toBe("radar-en");
+    expect(REPORT_LABELS["ai-radar"]).toBe("AI 信息雷达");
+    expect(REPORT_LABELS["ai-radar-en"]).toBe("AI Information Radar");
+    expect(NOTIFY_LABELS["ai-radar"]?.zh).toBe("Top 5 信息雷达");
   });
 });
 

--- a/src/__tests__/link-utils.test.ts
+++ b/src/__tests__/link-utils.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest";
+import { acceptUniqueLink, createLinkDedupeState, normalizeTitle, normalizeUrl } from "../link-utils.ts";
+
+describe("normalizeUrl", () => {
+  it("normalizes host, ports, fragments, tracking parameters, query order, and trailing slash", () => {
+    expect(normalizeUrl("HTTPS://Example.COM:443/path/?utm_source=x&b=2&a=1&ref=hn#section")).toBe(
+      "https://example.com/path?a=1&b=2",
+    );
+  });
+
+  it("keeps the root slash and removes click identifiers", () => {
+    expect(normalizeUrl("https://Example.com/?gclid=abc&fbclid=def")).toBe("https://example.com/");
+  });
+});
+
+describe("normalizeTitle", () => {
+  it("folds case, punctuation, unicode width, and whitespace", () => {
+    expect(normalizeTitle("  ＡI—Agents:  A New Era! ")).toBe("ai agents a new era");
+  });
+});
+
+describe("acceptUniqueLink", () => {
+  it("rejects either a canonical URL duplicate or a normalized-title duplicate", () => {
+    const state = createLinkDedupeState();
+    expect(acceptUniqueLink({ title: "Alpha", url: "https://example.com/a?utm_source=hn" }, state)).toBe(
+      true,
+    );
+    expect(acceptUniqueLink({ title: "Beta", url: "https://EXAMPLE.com/a" }, state)).toBe(false);
+    expect(acceptUniqueLink({ title: "ALPHA!", url: "https://example.com/b" }, state)).toBe(false);
+    expect(state.duplicateCount).toBe(2);
+  });
+});

--- a/src/__tests__/notify.test.ts
+++ b/src/__tests__/notify.test.ts
@@ -33,6 +33,12 @@ describe("buildMessage", () => {
     expect(msg).not.toContain("HN Community");
   });
 
+  it("renders Radar bilingual links", () => {
+    const msg = buildMessage("2026-08-12", ["ai-radar", "ai-radar-en"], BASE_URL);
+    expect(msg).toContain("Top 5 信息雷达");
+    expect(msg).toContain("#2026-08-12/ai-radar-en");
+  });
+
   it("includes Web UI and RSS links", () => {
     const msg = buildMessage("2026-03-09", ["ai-cli"], BASE_URL);
     expect(msg).toContain("🌐 Web UI");

--- a/src/__tests__/prompt-builders.test.ts
+++ b/src/__tests__/prompt-builders.test.ts
@@ -339,6 +339,8 @@ describe("buildHnPrompt", () => {
         },
       ],
       fetchSuccess: true,
+      scannedCount: 1,
+      duplicateCount: 0,
     };
     const result = buildHnPrompt(data, "2026-03-09");
     expect(result).toContain("AI News");
@@ -363,6 +365,8 @@ describe("buildHnPrompt", () => {
         },
       ],
       fetchSuccess: true,
+      scannedCount: 1,
+      duplicateCount: 0,
     };
     const result = buildHnPrompt(data, "2026-03-09", "en");
     expect(result).toContain("Score: 10");

--- a/src/__tests__/prompt-builders.test.ts
+++ b/src/__tests__/prompt-builders.test.ts
@@ -8,7 +8,12 @@ import {
   buildPeersComparisonPrompt,
   buildSkillsPrompt,
 } from "../prompts.ts";
-import { buildTrendingPrompt, buildWebReportPrompt, buildHnPrompt } from "../prompts-data.ts";
+import {
+  buildTrendingPrompt,
+  buildWebReportPrompt,
+  buildHnPrompt,
+  buildRadarPrompt,
+} from "../prompts-data.ts";
 import type { RepoConfig, GitHubItem, GitHubRelease } from "../github.ts";
 import type { RepoDigest } from "../prompts.ts";
 import type { TrendingData } from "../trending.ts";
@@ -372,5 +377,31 @@ describe("buildHnPrompt", () => {
     expect(result).toContain("Score: 10");
     expect(result).toContain("Comments: 2");
     expect(result).toContain("Hacker News");
+  });
+});
+
+describe("buildRadarPrompt", () => {
+  it("includes every stable candidate ID and the exact bilingual JSON fields", () => {
+    const stories = [
+      {
+        id: "123",
+        hnRank: 4,
+        title: "AI News",
+        url: "https://example.com/ai",
+        hnUrl: "https://news.ycombinator.com/item?id=123",
+        points: 200,
+        comments: 50,
+        author: "bob",
+        createdAt: "2026-08-11T10:00:00.000Z",
+      },
+    ];
+    const prompt = buildRadarPrompt(stories, "2026-08-12");
+    expect(prompt).toContain('"id": "123"');
+    expect(prompt).toContain('"relevance"');
+    expect(prompt).toContain('"novelty"');
+    expect(prompt).toContain('"actionability"');
+    expect(prompt).toContain('"summary": { "zh"');
+    expect(prompt).toContain('"reason": { "zh"');
+    expect(prompt).toContain("Do not change IDs, URLs, points, or comments");
   });
 });

--- a/src/__tests__/radar.test.ts
+++ b/src/__tests__/radar.test.ts
@@ -161,6 +161,21 @@ describe("generateRadarData", () => {
     expect(result.top5.map((item) => item.story.id)).toEqual(["1", "2", "3", "4", "5"]);
   });
 
+  it("falls back when a rejection reason cannot be coerced to a string", async () => {
+    const result = await generateRadarData(
+      {
+        stories: [story("1")],
+        fetchSuccess: true,
+        scannedCount: 1,
+        duplicateCount: 0,
+      },
+      NOW,
+      async () => Promise.reject(Object.create(null)),
+    );
+    expect(result.mode).toBe("deterministic");
+    expect(result.items[0]?.editorialScore).toBe(0);
+  });
+
   it("uses exact bilingual deterministic fallback summary and reason copy", async () => {
     const stories = [story("1", { title: "Agent launch", points: 42, comments: 7 })];
     const result = await generateRadarData(

--- a/src/__tests__/radar.test.ts
+++ b/src/__tests__/radar.test.ts
@@ -64,6 +64,20 @@ const editorial = (ids: string[]) => ({
 });
 
 describe("generateRadarData", () => {
+  it("calls the bilingual editorial loader exactly once", async () => {
+    const stories = [story("1"), story("2")];
+    let calls = 0;
+    await generateRadarData(
+      { stories, fetchSuccess: true, scannedCount: 2, duplicateCount: 0 },
+      NOW,
+      async () => {
+        calls += 1;
+        return editorial(["1", "2"]);
+      },
+    );
+    expect(calls).toBe(1);
+  });
+
   it("merges one valid editorial record per candidate and selects five unique items", async () => {
     const stories = Array.from({ length: 6 }, (_, index) => story(String(index + 1), { points: 60 - index }));
     const result = await generateRadarData(

--- a/src/__tests__/radar.test.ts
+++ b/src/__tests__/radar.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 import type { HnStory } from "../hn.ts";
-import { scoreRadarBase } from "../radar.ts";
+import { generateRadarData, scoreRadarBase } from "../radar.ts";
 
 const NOW = new Date("2026-08-12T00:00:00.000Z");
 
@@ -49,5 +49,167 @@ describe("scoreRadarBase", () => {
     );
     expect(scored.map((item) => item.breakdown.points)).toEqual([25, 25]);
     expect(scored.map((item) => item.breakdown.comments)).toEqual([10, 10]);
+  });
+});
+
+const editorial = (ids: string[]) => ({
+  items: ids.map((id) => ({
+    id,
+    relevance: 10,
+    novelty: 8,
+    actionability: 7,
+    summary: { zh: `摘要 ${id}`, en: `Summary ${id}` },
+    reason: { zh: `理由 ${id}`, en: `Reason ${id}` },
+  })),
+});
+
+describe("generateRadarData", () => {
+  it("merges one valid editorial record per candidate and selects five unique items", async () => {
+    const stories = Array.from({ length: 6 }, (_, index) => story(String(index + 1), { points: 60 - index }));
+    const result = await generateRadarData(
+      { stories, fetchSuccess: true, scannedCount: 8, duplicateCount: 2 },
+      NOW,
+      async () => editorial(stories.map((item) => item.id)),
+    );
+    expect(result.mode).toBe("deepseek");
+    expect(result.top5).toHaveLength(5);
+    expect(new Set(result.top5.map((item) => item.story.id)).size).toBe(5);
+    expect(result.items.every((item) => item.editorialScore === 25)).toBe(true);
+  });
+
+  const validTwo = editorial(["1", "2"]);
+  const invalidEditorialPayloads = [
+    {
+      name: "out-of-range score",
+      payload: {
+        items: validTwo.items.map((item, index) => (index === 0 ? { ...item, relevance: 11 } : item)),
+      },
+    },
+    {
+      name: "non-integer score",
+      payload: {
+        items: validTwo.items.map((item, index) => (index === 0 ? { ...item, novelty: 7.5 } : item)),
+      },
+    },
+    {
+      name: "unknown ID",
+      payload: {
+        items: validTwo.items.map((item, index) => (index === 0 ? { ...item, id: "unknown" } : item)),
+      },
+    },
+    {
+      name: "duplicate ID",
+      payload: {
+        items: validTwo.items.map((item, index) => (index === 1 ? { ...item, id: "1" } : item)),
+      },
+    },
+    { name: "missing ID", payload: { items: validTwo.items.slice(0, 1) } },
+    {
+      name: "blank Chinese summary",
+      payload: {
+        items: validTwo.items.map((item, index) =>
+          index === 0 ? { ...item, summary: { ...item.summary, zh: "  " } } : item,
+        ),
+      },
+    },
+    {
+      name: "missing English summary",
+      payload: {
+        items: validTwo.items.map((item, index) =>
+          index === 0 ? { ...item, summary: { zh: item.summary.zh } } : item,
+        ),
+      },
+    },
+    {
+      name: "blank Chinese reason",
+      payload: {
+        items: validTwo.items.map((item, index) =>
+          index === 0 ? { ...item, reason: { ...item.reason, zh: "\t" } } : item,
+        ),
+      },
+    },
+    {
+      name: "missing English reason",
+      payload: {
+        items: validTwo.items.map((item, index) =>
+          index === 0 ? { ...item, reason: { zh: item.reason.zh } } : item,
+        ),
+      },
+    },
+  ];
+
+  it.each(invalidEditorialPayloads)("falls back for $name", async ({ payload }) => {
+    const stories = [story("1"), story("2")];
+    const result = await generateRadarData(
+      { stories, fetchSuccess: true, scannedCount: 2, duplicateCount: 0 },
+      NOW,
+      async () => payload,
+    );
+    expect(result.mode).toBe("deterministic");
+    expect(result.items.every((item) => item.editorialScore === 0)).toBe(true);
+    expect(result.items.every((item) => item.totalScore === (item.baseScore / 70) * 100)).toBe(true);
+  });
+
+  it("falls back when JSON parsing is represented by a rejected loader", async () => {
+    const stories = Array.from({ length: 6 }, (_, index) => story(String(index + 1), { hnRank: 5 }));
+    const result = await generateRadarData(
+      { stories, fetchSuccess: true, scannedCount: 6, duplicateCount: 0 },
+      NOW,
+      async () => Promise.reject(new SyntaxError("invalid JSON")),
+    );
+    expect(result.mode).toBe("deterministic");
+    expect(result.top5.map((item) => item.story.id)).toEqual(["1", "2", "3", "4", "5"]);
+  });
+
+  it("uses exact bilingual deterministic fallback summary and reason copy", async () => {
+    const stories = [story("1", { title: "Agent launch", points: 42, comments: 7 })];
+    const result = await generateRadarData(
+      { stories, fetchSuccess: true, scannedCount: 1, duplicateCount: 0 },
+      NOW,
+      async () => Promise.reject(new Error("offline")),
+    );
+    expect(result.items[0]?.summary).toEqual({
+      zh: "HN 热门条目：Agent launch（42 分，7 条评论）。",
+      en: "HN item: Agent launch (42 points, 7 comments).",
+    });
+    expect(result.items[0]?.reason).toEqual({
+      zh: "基于 HN 排名、热度、讨论度与时效性的确定性推荐。",
+      en: "Deterministic recommendation based on HN rank, popularity, discussion, and freshness.",
+    });
+  });
+
+  it("uses HN rank before a numeric-aware candidate ID tie-breaker", async () => {
+    const stories = [
+      story("10", { hnRank: 5 }),
+      story("2", { hnRank: 5 }),
+      story("1", { hnRank: 5 }),
+      story("3", { hnRank: 4 }),
+    ];
+    const result = await generateRadarData(
+      { stories, fetchSuccess: true, scannedCount: 4, duplicateCount: 0 },
+      NOW,
+      async () => Promise.reject(new Error("offline")),
+    );
+    expect(result.items.map((item) => item.story.id)).toEqual(["3", "1", "2", "10"]);
+  });
+
+  it("does not load editorial data when there are no candidates", async () => {
+    let loadCount = 0;
+    const result = await generateRadarData(
+      { stories: [], fetchSuccess: true, scannedCount: 0, duplicateCount: 0 },
+      NOW,
+      async () => {
+        loadCount += 1;
+        return editorial([]);
+      },
+    );
+    expect(loadCount).toBe(0);
+    expect(result).toEqual({
+      items: [],
+      top5: [],
+      mode: "deterministic",
+      scannedCount: 0,
+      duplicateCount: 0,
+    });
   });
 });

--- a/src/__tests__/radar.test.ts
+++ b/src/__tests__/radar.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "vitest";
+import type { HnStory } from "../hn.ts";
+import { scoreRadarBase } from "../radar.ts";
+
+const NOW = new Date("2026-08-12T00:00:00.000Z");
+
+function story(id: string, overrides: Partial<HnStory> = {}): HnStory {
+  return {
+    id,
+    hnRank: Number(id),
+    title: `AI story ${id}`,
+    url: `https://example.com/${id}`,
+    hnUrl: `https://news.ycombinator.com/item?id=${id}`,
+    points: 0,
+    comments: 0,
+    author: "author",
+    createdAt: NOW.toISOString(),
+    ...overrides,
+  };
+}
+
+describe("scoreRadarBase", () => {
+  it("keeps every component inside its declared range", () => {
+    const scored = scoreRadarBase(
+      [
+        story("1", { points: 0, comments: 0, hnRank: 1, createdAt: NOW.toISOString() }),
+        story("2", { points: 10_000, comments: 5_000, hnRank: 500, createdAt: "2026-08-09T00:00:00.000Z" }),
+      ],
+      NOW,
+    );
+    for (const item of scored) {
+      expect(item.breakdown.points).toBeGreaterThanOrEqual(0);
+      expect(item.breakdown.points).toBeLessThanOrEqual(25);
+      expect(item.breakdown.comments).toBeGreaterThanOrEqual(0);
+      expect(item.breakdown.comments).toBeLessThanOrEqual(10);
+      expect(item.breakdown.rank).toBeGreaterThanOrEqual(0);
+      expect(item.breakdown.rank).toBeLessThanOrEqual(20);
+      expect(item.breakdown.freshness).toBeGreaterThanOrEqual(0);
+      expect(item.breakdown.freshness).toBeLessThanOrEqual(15);
+      expect(item.baseScore).toBeGreaterThanOrEqual(0);
+      expect(item.baseScore).toBeLessThanOrEqual(70);
+    }
+  });
+
+  it("gives equal non-zero batch values equal full popularity components", () => {
+    const scored = scoreRadarBase(
+      [story("1", { points: 100, comments: 20 }), story("2", { points: 100, comments: 20 })],
+      NOW,
+    );
+    expect(scored.map((item) => item.breakdown.points)).toEqual([25, 25]);
+    expect(scored.map((item) => item.breakdown.comments)).toEqual([10, 10]);
+  });
+});

--- a/src/__tests__/report-builders.test.ts
+++ b/src/__tests__/report-builders.test.ts
@@ -261,6 +261,38 @@ describe("buildRadarReportContent", () => {
     expect(html).toContain('<a href="https://news.ycombinator.com/item?id=1">HN discussion</a>');
   });
 
+  it.each([
+    ["closing parenthesis", "https://example.com/a)tail", "https://example.com/a)tail"],
+    ["less-than sign", "https://example.com/a<tail", "https://example.com/a%3Ctail"],
+    ["greater-than sign", "https://example.com/a>tail", "https://example.com/a%3Etail"],
+    ["whitespace", "https://example.com/a tail", "https://example.com/a%20tail"],
+    ["backslash", "https://example.com/a\\tail", "https://example.com/a%5Ctail"],
+    ["C1 control", "https://example.com/a\u0085tail", "https://example.com/a%C2%85tail"],
+    ["lone surrogate", "https://example.com/a\uD800tail", "https://example.com/a%EF%BF%BDtail"],
+  ])("preserves %s in parsed Top 5 and table article links", (_case, inputUrl, expectedHref) => {
+    const data = makeRadarData(1, "deepseek");
+    data.items[0]!.story.url = inputUrl;
+
+    const markdown = buildRadarReportContent(data, "2026-08-12 00:00", "2026-08-12", "", "en");
+    const html = marked.parse(markdown, { async: false });
+    expect(markdown).toContain(`(<${expectedHref}>)`);
+    const articleHrefs = Array.from(html.matchAll(/<a href="([^"]+)">AI story 1<\/a>/g), (match) => match[1]);
+
+    expect(articleHrefs).toEqual([expectedHref, expectedHref]);
+    expect(html).toContain('<a href="https://news.ycombinator.com/item?id=1">HN discussion</a>');
+  });
+
+  it("preserves a backslash followed by a pipe in a parsed table link label", () => {
+    const data = makeRadarData(1, "deepseek");
+    data.items[0]!.story.title = String.raw`alpha \| beta`;
+
+    const markdown = buildRadarReportContent(data, "2026-08-12 00:00", "2026-08-12", "", "en");
+    const html = marked.parse(markdown, { async: false });
+    const cells = Array.from(html.matchAll(/<td[^>]*>(.*?)<\/td>/g), (match) => match[1]);
+
+    expect(cells).toContain(String.raw`<a href="https://example.com/1">alpha \| beta</a>`);
+  });
+
   it("caps recommendations at the first five items even when top5 is oversized", () => {
     const data = makeRadarData(6, "deepseek");
     data.top5 = data.items;

--- a/src/__tests__/report-builders.test.ts
+++ b/src/__tests__/report-builders.test.ts
@@ -1,3 +1,4 @@
+import { marked } from "marked";
 import { describe, it, expect } from "vitest";
 import {
   buildCliReportContent,
@@ -248,5 +249,29 @@ describe("buildRadarReportContent", () => {
     expect(result).toContain("Deterministic fallback");
     expect(result).toContain("Only 3 candidates were available");
     expect(result.match(/^### \d+\./gm) ?? []).toHaveLength(3);
+  });
+
+  it("preserves external story titles and distinct article and HN discussion anchors", () => {
+    const data = makeRadarData(1, "deepseek");
+    data.items[0]!.story.title = "A ] B";
+    const markdown = buildRadarReportContent(data, "2026-08-12 00:00", "2026-08-12", "", "en");
+    const html = marked.parse(markdown, { async: false });
+
+    expect(html.match(/<a href="https:\/\/example\.com\/1">A \] B<\/a>/g) ?? []).toHaveLength(2);
+    expect(html).toContain('<a href="https://news.ycombinator.com/item?id=1">HN discussion</a>');
+  });
+
+  it("caps recommendations at the first five items even when top5 is oversized", () => {
+    const data = makeRadarData(6, "deepseek");
+    data.top5 = data.items;
+    const result = buildRadarReportContent(data, "2026-08-12 00:00", "2026-08-12", "", "en");
+
+    expect(result.match(/^### \d+\. \[AI story \d+\]/gm) ?? []).toEqual([
+      "### 1. [AI story 1]",
+      "### 2. [AI story 2]",
+      "### 3. [AI story 3]",
+      "### 4. [AI story 4]",
+      "### 5. [AI story 5]",
+    ]);
   });
 });

--- a/src/__tests__/report-builders.test.ts
+++ b/src/__tests__/report-builders.test.ts
@@ -293,6 +293,18 @@ describe("buildRadarReportContent", () => {
     expect(cells).toContain(String.raw`<a href="https://example.com/1">alpha \| beta</a>`);
   });
 
+  it("preserves a backslash followed by a pipe in the parsed summary cell", () => {
+    const data = makeRadarData(1, "deepseek");
+    data.items[0]!.summary.en = String.raw`alpha \| beta`;
+
+    const markdown = buildRadarReportContent(data, "2026-08-12 00:00", "2026-08-12", "", "en");
+    const html = marked.parse(markdown, { async: false });
+    const cells = Array.from(html.matchAll(/<td[^>]*>(.*?)<\/td>/g), (match) => match[1]);
+
+    expect(cells).toHaveLength(7);
+    expect(cells[5]).toBe("2026-08-11T00:00:00.000Z");
+    expect(cells[6]).toBe(String.raw`alpha \| beta`);
+  });
   it("caps recommendations at the first five items even when top5 is oversized", () => {
     const data = makeRadarData(6, "deepseek");
     data.top5 = data.items;

--- a/src/__tests__/report-builders.test.ts
+++ b/src/__tests__/report-builders.test.ts
@@ -3,9 +3,11 @@ import {
   buildCliReportContent,
   buildOpenclawReportContent,
   buildInfraReportContent,
+  buildRadarReportContent,
 } from "../report-builders.ts";
 import type { RepoDigest } from "../prompts.ts";
 import type { GitHubItem, GitHubRelease } from "../github.ts";
+import type { RadarData } from "../radar.ts";
 
 // ---------------------------------------------------------------------------
 // Fixtures
@@ -19,6 +21,35 @@ function makeDigest(overrides: Partial<RepoDigest> = {}): RepoDigest {
     releases: [],
     summary: "Test summary content",
     ...overrides,
+  };
+}
+
+function makeRadarData(count: number, mode: RadarData["mode"]): RadarData {
+  const items: RadarData["items"] = Array.from({ length: count }, (_, index) => ({
+    story: {
+      id: String(index + 1),
+      hnRank: index + 1,
+      title: `AI story ${index + 1}`,
+      url: `https://example.com/${index + 1}`,
+      hnUrl: `https://news.ycombinator.com/item?id=${index + 1}`,
+      points: 100 - index,
+      comments: 20 - index,
+      author: "author",
+      createdAt: "2026-08-11T00:00:00.000Z",
+    },
+    breakdown: { points: 20, comments: 8, rank: 19, freshness: 10 },
+    baseScore: 57,
+    editorialScore: mode === "deepseek" ? 25 : 0,
+    totalScore: 95 - index,
+    summary: { zh: `摘要 ${index + 1}`, en: `Summary ${index + 1}` },
+    reason: { zh: `理由 ${index + 1}`, en: `Reason ${index + 1}` },
+  }));
+  return {
+    items,
+    top5: items.slice(0, 5),
+    mode,
+    scannedCount: count + 2,
+    duplicateCount: 2,
   };
 }
 
@@ -190,5 +221,32 @@ describe("buildInfraReportContent", () => {
     expect(result).toContain("Projects covered: 1");
     expect(result).toContain("Cross-Project Comparison");
     expect(result).toContain("Per-Project Reports");
+  });
+});
+
+describe("buildRadarReportContent", () => {
+  it("renders metadata, exactly five recommendations, and every candidate in Chinese", () => {
+    const data = makeRadarData(6, "deepseek");
+    const result = buildRadarReportContent(data, "2026-08-12 00:00", "2026-08-12", "\nfooter", "zh");
+    expect(result).toContain("# AI 信息雷达 2026-08-12");
+    expect(result).toContain("扫描 8 条");
+    expect(result).toContain("候选 6 条");
+    expect(result).toContain("去重 2 条");
+    expect(result).toContain("DeepSeek 编辑评分");
+    expect(result.match(/^### \d+\./gm) ?? []).toHaveLength(5);
+    expect(result.match(/^\| \d+ \|/gm) ?? []).toHaveLength(6);
+    expect(new Set(data.top5.map((item) => item.story.url)).size).toBe(5);
+    for (const item of data.top5) {
+      expect(result.split(item.story.url)).toHaveLength(3);
+    }
+  });
+
+  it("marks deterministic mode and renders all available items when fewer than five exist", () => {
+    const data = makeRadarData(3, "deterministic");
+    const result = buildRadarReportContent(data, "2026-08-12 00:00", "2026-08-12", "", "en");
+    expect(result).toContain("# AI Information Radar 2026-08-12");
+    expect(result).toContain("Deterministic fallback");
+    expect(result).toContain("Only 3 candidates were available");
+    expect(result.match(/^### \d+\./gm) ?? []).toHaveLength(3);
   });
 });

--- a/src/__tests__/report.test.ts
+++ b/src/__tests__/report.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import fs from "node:fs";
+import path from "node:path";
 
 // ---------------------------------------------------------------------------
 // Mock provider — intercepts createProvider() so the module-level `provider`
@@ -81,17 +82,21 @@ describe("saveFile", () => {
 
   it("returns the expected file path", () => {
     const result = saveFile("content", "2026-03-09", "ai-cli.md");
-    expect(result).toBe("digests/2026-03-09/ai-cli.md");
+    expect(result).toBe(path.join("digests", "2026-03-09", "ai-cli.md"));
   });
 
   it("creates parent directories recursively", () => {
     saveFile("content", "2026-03-09", "ai-cli.md");
-    expect(fs.mkdirSync).toHaveBeenCalledWith("digests/2026-03-09", { recursive: true });
+    expect(fs.mkdirSync).toHaveBeenCalledWith(path.join("digests", "2026-03-09"), { recursive: true });
   });
 
   it("writes content as utf-8", () => {
     saveFile("hello world", "2026-03-09", "test.md");
-    expect(fs.writeFileSync).toHaveBeenCalledWith("digests/2026-03-09/test.md", "hello world", "utf-8");
+    expect(fs.writeFileSync).toHaveBeenCalledWith(
+      path.join("digests", "2026-03-09", "test.md"),
+      "hello world",
+      "utf-8",
+    );
   });
 });
 

--- a/src/generate-manifest.ts
+++ b/src/generate-manifest.ts
@@ -8,7 +8,7 @@ const MANIFEST_PATH = "manifest.json";
 const FEED_PATH = "feed.xml";
 const SITE_URL = "https://duanyytop.github.io/agents-radar";
 const DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
-const REPORT_FILES = [
+export const REPORT_FILES: readonly string[] = [
   "ai-cli",
   "ai-cli-en",
   "ai-agents",
@@ -21,6 +21,8 @@ const REPORT_FILES = [
   "ai-trending-en",
   "ai-hn",
   "ai-hn-en",
+  "ai-radar",
+  "ai-radar-en",
   "ai-ph",
   "ai-ph-en",
   "ai-arxiv",
@@ -35,7 +37,7 @@ const REPORT_FILES = [
   "ai-weekly-en",
   "ai-monthly",
   "ai-monthly-en",
-] as const;
+];
 const MAX_FEED_ITEMS = 30;
 
 interface DateEntry {

--- a/src/github.ts
+++ b/src/github.ts
@@ -202,6 +202,8 @@ const LABEL_COLORS: Record<string, string> = {
   "web-en": "6366f1",
   "trending-en": "fbbf24",
   "hn-en": "fb923c",
+  radar: "0ea5e9",
+  "radar-en": "38bdf8",
   "ph-en": "e8854a",
   arxiv: "b31b1b",
   "arxiv-en": "d44a4a",

--- a/src/hn.ts
+++ b/src/hn.ts
@@ -2,6 +2,8 @@
  * Hacker News AI stories fetched from the official Firebase API.
  */
 
+import { acceptUniqueLink, createLinkDedupeState } from "./link-utils.ts";
+
 // ---------------------------------------------------------------------------
 // Types
 // ---------------------------------------------------------------------------
@@ -21,6 +23,8 @@ export interface HnStory {
 export interface HnData {
   stories: HnStory[];
   fetchSuccess: boolean;
+  scannedCount: number;
+  duplicateCount: number;
 }
 
 // ---------------------------------------------------------------------------
@@ -105,14 +109,17 @@ export async function fetchHnData(): Promise<HnData> {
     });
     if (!topResp.ok) {
       console.error(`  [hn] topstories: HTTP ${topResp.status}`);
-      return { stories: [], fetchSuccess: false };
+      return { stories: [], fetchSuccess: false, scannedCount: 0, duplicateCount: 0 };
     }
 
     const topIds = ((await topResp.json()) as number[]).slice(0, HN_STORIES_TO_SCAN);
     const stories: HnStory[] = [];
+    const dedupeState = createLinkDedupeState();
+    let scannedCount = 0;
 
     for (let i = 0; i < topIds.length && stories.length < HN_TOP_STORIES; i += HN_BATCH_SIZE) {
       const batchIds = topIds.slice(i, i + HN_BATCH_SIZE);
+      scannedCount += batchIds.length;
       const items = await Promise.all(
         batchIds.map(async (id): Promise<HnFirebaseItem | null> => {
           const resp = await fetch(HN_ITEM_URL(id), {
@@ -128,19 +135,22 @@ export async function fetchHnData(): Promise<HnData> {
 
       for (let j = 0; j < items.length && stories.length < HN_TOP_STORIES; j += 1) {
         const item = items[j];
-        if (!item || item.deleted || item.dead || item.type !== "story" || !item.title) {
-          continue;
-        }
-        if (isAiRelated(item)) {
-          stories.push(toHnStory(item, i + j + 1));
-        }
+        if (!item || item.deleted || item.dead || item.type !== "story" || !item.title) continue;
+        if (!isAiRelated(item)) continue;
+        const story = toHnStory(item, i + j + 1);
+        if (acceptUniqueLink(story, dedupeState)) stories.push(story);
       }
     }
 
     console.log(`  [hn] ${stories.length} AI stories (scanned ${topIds.length} topstories)`);
-    return { stories, fetchSuccess: stories.length > 0 };
+    return {
+      stories,
+      fetchSuccess: stories.length > 0,
+      scannedCount,
+      duplicateCount: dedupeState.duplicateCount,
+    };
   } catch (err) {
     console.error(`  [hn] fetch failed: ${err}`);
-    return { stories: [], fetchSuccess: false };
+    return { stories: [], fetchSuccess: false, scannedCount: 0, duplicateCount: 0 };
   }
 }

--- a/src/hn.ts
+++ b/src/hn.ts
@@ -122,14 +122,19 @@ export async function fetchHnData(): Promise<HnData> {
       scannedCount += batchIds.length;
       const items = await Promise.all(
         batchIds.map(async (id): Promise<HnFirebaseItem | null> => {
-          const resp = await fetch(HN_ITEM_URL(id), {
-            headers: { "User-Agent": "agents-radar/1.0" },
-          });
-          if (!resp.ok) {
-            console.error(`  [hn] item ${id}: HTTP ${resp.status}`);
+          try {
+            const resp = await fetch(HN_ITEM_URL(id), {
+              headers: { "User-Agent": "agents-radar/1.0" },
+            });
+            if (!resp.ok) {
+              console.error(`  [hn] item ${id}: HTTP ${resp.status}`);
+              return null;
+            }
+            return (await resp.json()) as HnFirebaseItem;
+          } catch {
+            console.error(`  [hn] item ${id}: request failed`);
             return null;
           }
-          return (await resp.json()) as HnFirebaseItem;
         }),
       );
 
@@ -142,7 +147,7 @@ export async function fetchHnData(): Promise<HnData> {
       }
     }
 
-    console.log(`  [hn] ${stories.length} AI stories (scanned ${topIds.length} topstories)`);
+    console.log(`  [hn] ${stories.length} AI stories (scanned ${scannedCount} topstories)`);
     return {
       stories,
       fetchSuccess: stories.length > 0,

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -85,6 +85,41 @@ export const HN_REPORT = {
     lang === "en" ? `📰 Hacker News AI Digest ${dateStr}` : `📰 Hacker News AI 社区动态日报 ${dateStr}`,
 } as const;
 
+export const RADAR_REPORT = {
+  title: t("AI 信息雷达", "AI Information Radar"),
+  source: t("数据来源: Hacker News Top Stories", "Source: Hacker News Top Stories"),
+  mode: {
+    deepseek: t("DeepSeek 编辑评分", "DeepSeek editorial scoring"),
+    deterministic: t("确定性降级模式", "Deterministic fallback"),
+  },
+  meta: (
+    scanned: number,
+    candidates: number,
+    duplicates: number,
+    mode: string,
+    utcStr: string,
+    lang: Lang,
+  ) =>
+    lang === "en"
+      ? `> Source: Hacker News Top Stories | Scanned ${scanned} | Candidates ${candidates} | Duplicates ${duplicates} | Scoring: ${mode} | Generated: ${utcStr} UTC`
+      : `> 数据来源: Hacker News Top Stories | 扫描 ${scanned} 条 | 候选 ${candidates} 条 | 去重 ${duplicates} 条 | 评分模式: ${mode} | 生成时间: ${utcStr} UTC`,
+  top5: t("今日 Top 5", "Today's Top 5"),
+  allCandidates: t("全部候选", "All Candidates"),
+  reason: t("推荐理由", "Why it is recommended"),
+  discussion: t("HN 讨论", "HN discussion"),
+  tableHeader: t(
+    "| 排名 | 标题 | 总分 | Points | Comments | 发布时间 | 摘要 |",
+    "| Rank | Title | Score | Points | Comments | Published | Summary |",
+  ),
+  tableAlign: "| ---: | :--- | ---: | ---: | ---: | :--- | :--- |",
+  insufficient: (count: number, lang: Lang) =>
+    lang === "en"
+      ? `Only ${count} candidates were available; no duplicate items were added.`
+      : `当前仅有 ${count} 条候选，未使用重复条目补齐。`,
+  issueTitle: (dateStr: string, lang: Lang) =>
+    lang === "en" ? `📡 AI Information Radar ${dateStr}` : `📡 AI 信息雷达 ${dateStr}`,
+} as const;
+
 export const RADAR_FALLBACK = {
   summary: (title: string, points: number, comments: number): Record<Lang, string> =>
     t(
@@ -128,6 +163,7 @@ export const ISSUE_LABELS = {
   web: t("web", "web-en"),
   trending: t("trending", "trending-en"),
   hn: t("hn", "hn-en"),
+  radar: t("radar", "radar-en"),
   ph: t("ph", "ph-en"),
   arxiv: t("arxiv", "arxiv-en"),
   hf: t("hf", "hf-en"),
@@ -172,6 +208,8 @@ export const REPORT_LABELS: Record<string, string> = {
   "ai-trending-en": "AI Open Source Trends",
   "ai-hn": "Hacker News AI 社区动态日报",
   "ai-hn-en": "Hacker News AI Community Digest",
+  "ai-radar": "AI 信息雷达",
+  "ai-radar-en": "AI Information Radar",
   "ai-ph": "Product Hunt AI 产品日报",
   "ai-ph-en": "Product Hunt AI Products Digest",
   "ai-arxiv": "ArXiv AI 研究日报",
@@ -195,6 +233,7 @@ export const NOTIFY_LABELS: Record<string, Record<Lang, string>> = {
   "ai-web": t("官网动态", "Official Updates"),
   "ai-trending": t("GitHub 趋势", "GitHub Trends"),
   "ai-hn": t("HN 社区动态", "HN Community"),
+  "ai-radar": t("Top 5 信息雷达", "Top 5 Radar"),
   "ai-ph": t("Product Hunt", "Product Hunt"),
   "ai-arxiv": t("ArXiv 研究", "ArXiv Research"),
   "ai-hf": t("HF 模型", "HF Models"),

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -85,6 +85,18 @@ export const HN_REPORT = {
     lang === "en" ? `📰 Hacker News AI Digest ${dateStr}` : `📰 Hacker News AI 社区动态日报 ${dateStr}`,
 } as const;
 
+export const RADAR_FALLBACK = {
+  summary: (title: string, points: number, comments: number): Record<Lang, string> =>
+    t(
+      `HN 热门条目：${title}（${points} 分，${comments} 条评论）。`,
+      `HN item: ${title} (${points} points, ${comments} comments).`,
+    ),
+  reason: t(
+    "基于 HN 排名、热度、讨论度与时效性的确定性推荐。",
+    "Deterministic recommendation based on HN rank, popularity, discussion, and freshness.",
+  ),
+} as const;
+
 export const PH_REPORT = {
   title: t("Product Hunt AI 产品日报", "Product Hunt AI Products Digest"),
   issueTitle: (dateStr: string, lang: Lang) =>

--- a/src/index.ts
+++ b/src/index.ts
@@ -173,7 +173,9 @@ async function fetchAllData(
         trendingFetchSuccess: false,
       }),
     ),
-    fetchHnData().catch((): HnData => ({ stories: [], fetchSuccess: false })),
+    fetchHnData().catch(
+      (): HnData => ({ stories: [], fetchSuccess: false, scannedCount: 0, duplicateCount: 0 }),
+    ),
     fetchPhData().catch((): PhData => ({ products: [], fetchSuccess: false })),
     fetchArxivData().catch((): ArxivData => ({ papers: [], fetchSuccess: false })),
     fetchHfData().catch((): HfData => ({ models: [], fetchSuccess: false })),

--- a/src/index.ts
+++ b/src/index.ts
@@ -29,8 +29,20 @@ import {
   buildPeersComparisonPrompt,
   buildSkillsPrompt,
 } from "./prompts.ts";
-import { buildTrendingPrompt, buildHighlightsPrompt, type ReportHighlights } from "./prompts-data.ts";
-import { callLlm, parseLlmJson, saveFile, autoGenFooter, LLM_TOKENS_TRENDING } from "./report.ts";
+import {
+  buildTrendingPrompt,
+  buildHighlightsPrompt,
+  buildRadarPrompt,
+  type ReportHighlights,
+} from "./prompts-data.ts";
+import {
+  callLlm,
+  parseLlmJson,
+  saveFile,
+  autoGenFooter,
+  LLM_TOKENS_TRENDING,
+  LLM_TOKENS_LISTING,
+} from "./report.ts";
 import {
   buildCliReportContent,
   buildOpenclawReportContent,
@@ -44,10 +56,12 @@ import {
   saveArxivReport,
   saveHfReport,
   saveCommunityReport,
+  saveRadarReport,
 } from "./report-savers.ts";
 import { loadWebState, fetchSiteContent, type WebFetchResult, type WebState } from "./web.ts";
 import { fetchTrendingData, type TrendingData } from "./trending.ts";
 import { fetchHnData, type HnData } from "./hn.ts";
+import { generateRadarData } from "./radar.ts";
 import { fetchPhData, type PhData } from "./ph.ts";
 import { fetchArxivData, type ArxivData } from "./arxiv.ts";
 import { fetchHfData, type HfData } from "./hf.ts";
@@ -347,6 +361,12 @@ async function main(): Promise<void> {
     lobstersData,
   } = await fetchAllData(since, webState);
 
+  const radarDataPromise = generateRadarData(hnData, now, async () => {
+    console.log("  [radar] Calling LLM for bilingual editorial scoring...");
+    const raw = await callLlm(buildRadarPrompt(hnData.stories, dateStr), LLM_TOKENS_LISTING);
+    return parseLlmJson<unknown>(raw);
+  });
+
   const peerIds = new Set(OPENCLAW_PEERS.map((p) => p.id));
   const infraIds = new Set(INFRA_REPOS.map((r) => r.id));
   const fetchedCli = fetched.filter(
@@ -465,6 +485,8 @@ async function main(): Promise<void> {
     await saveWebReport(webResults, webState, utcStr, dateStr, digestRepo, autoGenFooter(lang), lang);
   }
 
+  const radarData = await radarDataPromise;
+
   await Promise.all([
     saveTrendingReport(
       trendingData,
@@ -486,6 +508,8 @@ async function main(): Promise<void> {
     ),
     saveHnReport(hnData, utcStr, dateStr, digestRepo, autoGenFooter("zh"), "zh"),
     saveHnReport(hnData, utcStr, dateStr, digestRepo, autoGenFooter("en"), "en"),
+    saveRadarReport(radarData, utcStr, dateStr, digestRepo, autoGenFooter("zh"), "zh"),
+    saveRadarReport(radarData, utcStr, dateStr, digestRepo, autoGenFooter("en"), "en"),
     savePhReport(phData, utcStr, dateStr, digestRepo, autoGenFooter("zh"), "zh"),
     savePhReport(phData, utcStr, dateStr, digestRepo, autoGenFooter("en"), "en"),
     saveArxivReport(arxivData, utcStr, dateStr, digestRepo, autoGenFooter("zh"), "zh"),
@@ -516,6 +540,7 @@ async function main(): Promise<void> {
     ["ai-trending", "ai-trending.md", "ai-trending-en.md"],
     ["ai-web", "ai-web.md", "ai-web-en.md"],
     ["ai-hn", "ai-hn.md", "ai-hn-en.md"],
+    ["ai-radar", "ai-radar.md", "ai-radar-en.md"],
     ["ai-ph", "ai-ph.md", "ai-ph-en.md"],
     ["ai-arxiv", "ai-arxiv.md", "ai-arxiv-en.md"],
     ["ai-hf", "ai-hf.md", "ai-hf-en.md"],

--- a/src/link-utils.ts
+++ b/src/link-utils.ts
@@ -1,0 +1,52 @@
+export interface LinkLike {
+  title: string;
+  url: string;
+}
+
+export interface LinkDedupeState {
+  seenUrls: Set<string>;
+  seenTitles: Set<string>;
+  duplicateCount: number;
+}
+
+const TRACKING_PARAMS = new Set(["ref", "source", "fbclid", "gclid"]);
+
+export function normalizeUrl(rawUrl: string): string {
+  const url = new URL(rawUrl);
+  url.hostname = url.hostname.toLowerCase();
+  if ((url.protocol === "https:" && url.port === "443") || (url.protocol === "http:" && url.port === "80")) {
+    url.port = "";
+  }
+  url.hash = "";
+  for (const key of [...url.searchParams.keys()]) {
+    const lower = key.toLowerCase();
+    if (lower.startsWith("utm_") || TRACKING_PARAMS.has(lower)) url.searchParams.delete(key);
+  }
+  url.searchParams.sort();
+  if (url.pathname !== "/") url.pathname = url.pathname.replace(/\/+$/, "");
+  return url.toString();
+}
+
+export function normalizeTitle(title: string): string {
+  return title
+    .normalize("NFKC")
+    .toLowerCase()
+    .replace(/[^\p{L}\p{N}]+/gu, " ")
+    .trim();
+}
+
+export function createLinkDedupeState(): LinkDedupeState {
+  return { seenUrls: new Set(), seenTitles: new Set(), duplicateCount: 0 };
+}
+
+export function acceptUniqueLink(link: LinkLike, state: LinkDedupeState): boolean {
+  const urlKey = normalizeUrl(link.url);
+  const titleKey = normalizeTitle(link.title);
+  if (state.seenUrls.has(urlKey) || state.seenTitles.has(titleKey)) {
+    state.duplicateCount += 1;
+    return false;
+  }
+  state.seenUrls.add(urlKey);
+  state.seenTitles.add(titleKey);
+  return true;
+}

--- a/src/prompts-data.ts
+++ b/src/prompts-data.ts
@@ -6,7 +6,7 @@
 
 import type { WebFetchResult } from "./web.ts";
 import type { TrendingData } from "./trending.ts";
-import type { HnData } from "./hn.ts";
+import type { HnData, HnStory } from "./hn.ts";
 import type { PhData } from "./ph.ts";
 import type { ArxivData } from "./arxiv.ts";
 import type { HfData } from "./hf.ts";
@@ -873,4 +873,38 @@ ${lobstersText}
 
 语言要求：中文，简洁专业，保留所有原文链接。
 `;
+}
+
+export function buildRadarPrompt(stories: HnStory[], dateStr: string): string {
+  const candidates = stories.map((story) => ({
+    id: story.id,
+    hnRank: story.hnRank,
+    title: story.title,
+    url: story.url,
+    hnUrl: story.hnUrl,
+    points: story.points,
+    comments: story.comments,
+    createdAt: story.createdAt,
+  }));
+  return `You are the bilingual editor for an AI information radar dated ${dateStr}.
+Score every candidate exactly once. Relevance, novelty, and actionability must each be integers from 0 to 10.
+Write one concise Chinese and English summary and recommendation reason per item.
+Do not change IDs, URLs, points, or comments. Do not add or omit candidates.
+
+Candidates:
+${JSON.stringify(candidates, null, 2)}
+
+Return JSON only with this exact shape:
+{
+  "items": [
+    {
+      "id": "123",
+      "relevance": 0,
+      "novelty": 0,
+      "actionability": 0,
+      "summary": { "zh": "中文摘要", "en": "English summary" },
+      "reason": { "zh": "中文推荐理由", "en": "English recommendation reason" }
+    }
+  ]
+}`;
 }

--- a/src/radar.ts
+++ b/src/radar.ts
@@ -172,7 +172,7 @@ export async function generateRadarData(
     editorialById = new Map(validated.map((item) => [item.id, item]));
   } catch (error) {
     mode = "deterministic";
-    console.error(`  [radar] Editorial scoring failed; using deterministic fallback: ${error}`);
+    console.error("  [radar] Editorial scoring failed; using deterministic fallback:", error);
   }
 
   const items = baseItems

--- a/src/radar.ts
+++ b/src/radar.ts
@@ -1,0 +1,71 @@
+import type { HnStory } from "./hn.ts";
+import type { Lang } from "./i18n.ts";
+
+export interface RadarScoreBreakdown {
+  points: number;
+  comments: number;
+  rank: number;
+  freshness: number;
+}
+
+export interface RadarBaseItem {
+  story: HnStory;
+  breakdown: RadarScoreBreakdown;
+  baseScore: number;
+}
+
+export interface RadarEditorialItem {
+  id: string;
+  relevance: number;
+  novelty: number;
+  actionability: number;
+  summary: Record<Lang, string>;
+  reason: Record<Lang, string>;
+}
+
+export interface RadarItem extends RadarBaseItem {
+  editorialScore: number;
+  totalScore: number;
+  summary: Record<Lang, string>;
+  reason: Record<Lang, string>;
+}
+
+export interface RadarData {
+  items: RadarItem[];
+  top5: RadarItem[];
+  mode: "deepseek" | "deterministic";
+  scannedCount: number;
+  duplicateCount: number;
+}
+
+const clamp = (value: number, min: number, max: number): number => Math.min(max, Math.max(min, value));
+
+function logBatchScore(value: number, values: number[], weight: number): number {
+  const logs = values.map((entry) => Math.log1p(Math.max(0, entry)));
+  const current = Math.log1p(Math.max(0, value));
+  const min = Math.min(...logs);
+  const max = Math.max(...logs);
+  if (max === min) return max === 0 ? 0 : weight;
+  return ((current - min) / (max - min)) * weight;
+}
+
+export function scoreRadarBase(stories: HnStory[], now: Date): RadarBaseItem[] {
+  if (stories.length === 0) return [];
+  const points = stories.map((story) => story.points);
+  const comments = stories.map((story) => story.comments);
+  return stories.map((story) => {
+    const rank = clamp(story.hnRank ?? 500, 1, 500);
+    const ageHours = Math.max(0, (now.getTime() - new Date(story.createdAt).getTime()) / 3_600_000);
+    const breakdown = {
+      points: logBatchScore(story.points, points, 25),
+      comments: logBatchScore(story.comments, comments, 10),
+      rank: 20 * (1 - (rank - 1) / 499),
+      freshness: 15 * (1 - clamp(ageHours, 0, 48) / 48),
+    };
+    return {
+      story,
+      breakdown,
+      baseScore: breakdown.points + breakdown.comments + breakdown.rank + breakdown.freshness,
+    };
+  });
+}

--- a/src/radar.ts
+++ b/src/radar.ts
@@ -1,4 +1,5 @@
-import type { HnStory } from "./hn.ts";
+import type { HnData, HnStory } from "./hn.ts";
+import { RADAR_FALLBACK } from "./i18n.ts";
 import type { Lang } from "./i18n.ts";
 
 export interface RadarScoreBreakdown {
@@ -68,4 +69,139 @@ export function scoreRadarBase(stories: HnStory[], now: Date): RadarBaseItem[] {
       baseScore: breakdown.points + breakdown.comments + breakdown.rank + breakdown.freshness,
     };
   });
+}
+
+function requireRecord(value: unknown, label: string): Record<string, unknown> {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    throw new Error(`${label} must be an object`);
+  }
+  return value as Record<string, unknown>;
+}
+
+function requireScore(value: unknown, label: string): number {
+  if (typeof value !== "number" || !Number.isInteger(value) || value < 0 || value > 10) {
+    throw new Error(`${label} must be an integer from 0 to 10`);
+  }
+  return value;
+}
+
+function requireText(value: unknown, label: string): string {
+  if (typeof value !== "string" || value.trim().length === 0) {
+    throw new Error(`${label} must be a non-empty string`);
+  }
+  return value.trim();
+}
+
+function requireLocalized(value: unknown, label: string): Record<Lang, string> {
+  const record = requireRecord(value, label);
+  return {
+    zh: requireText(record["zh"], `${label}.zh`),
+    en: requireText(record["en"], `${label}.en`),
+  };
+}
+
+export function validateRadarEditorial(value: unknown, candidateIds: string[]): RadarEditorialItem[] {
+  const root = requireRecord(value, "editorial payload");
+  if (!Array.isArray(root["items"])) {
+    throw new Error("editorial payload.items must be an array");
+  }
+  if (root["items"].length !== candidateIds.length) {
+    throw new Error("editorial payload must contain exactly one item per candidate");
+  }
+
+  const expected = new Set(candidateIds);
+  const seen = new Set<string>();
+  const items = root["items"].map((value, index): RadarEditorialItem => {
+    const item = requireRecord(value, `items[${index}]`);
+    const id = requireText(item["id"], `items[${index}].id`);
+    if (!expected.has(id)) throw new Error(`unknown candidate id: ${id}`);
+    if (seen.has(id)) throw new Error(`duplicate candidate id: ${id}`);
+    seen.add(id);
+    return {
+      id,
+      relevance: requireScore(item["relevance"], `items[${index}].relevance`),
+      novelty: requireScore(item["novelty"], `items[${index}].novelty`),
+      actionability: requireScore(item["actionability"], `items[${index}].actionability`),
+      summary: requireLocalized(item["summary"], `items[${index}].summary`),
+      reason: requireLocalized(item["reason"], `items[${index}].reason`),
+    };
+  });
+
+  if (seen.size !== expected.size) throw new Error("editorial payload is missing candidate IDs");
+  return items;
+}
+
+function compareRadarItems(a: RadarItem, b: RadarItem): number {
+  return (
+    b.totalScore - a.totalScore ||
+    (a.story.hnRank ?? Number.POSITIVE_INFINITY) - (b.story.hnRank ?? Number.POSITIVE_INFINITY) ||
+    a.story.id.localeCompare(b.story.id, "en", { numeric: true })
+  );
+}
+
+function fallbackText(story: HnStory): Pick<RadarItem, "summary" | "reason"> {
+  return {
+    summary: RADAR_FALLBACK.summary(story.title, story.points, story.comments),
+    reason: RADAR_FALLBACK.reason,
+  };
+}
+
+export async function generateRadarData(
+  hnData: HnData,
+  now: Date,
+  loadEditorial: () => Promise<unknown>,
+): Promise<RadarData> {
+  const baseItems = scoreRadarBase(hnData.stories, now);
+  if (baseItems.length === 0) {
+    return {
+      items: [],
+      top5: [],
+      mode: "deterministic",
+      scannedCount: hnData.scannedCount,
+      duplicateCount: hnData.duplicateCount,
+    };
+  }
+
+  let mode: RadarData["mode"] = "deepseek";
+  let editorialById = new Map<string, RadarEditorialItem>();
+  try {
+    const validated = validateRadarEditorial(
+      await loadEditorial(),
+      hnData.stories.map((story) => story.id),
+    );
+    editorialById = new Map(validated.map((item) => [item.id, item]));
+  } catch (error) {
+    mode = "deterministic";
+    console.error(`  [radar] Editorial scoring failed; using deterministic fallback: ${error}`);
+  }
+
+  const items = baseItems
+    .map((base): RadarItem => {
+      const editorialItem = editorialById.get(base.story.id);
+      if (!editorialItem) {
+        return {
+          ...base,
+          editorialScore: 0,
+          totalScore: (base.baseScore / 70) * 100,
+          ...fallbackText(base.story),
+        };
+      }
+      const editorialScore = editorialItem.relevance + editorialItem.novelty + editorialItem.actionability;
+      return {
+        ...base,
+        editorialScore,
+        totalScore: base.baseScore + editorialScore,
+        summary: editorialItem.summary,
+        reason: editorialItem.reason,
+      };
+    })
+    .sort(compareRadarItems);
+
+  return {
+    items,
+    top5: items.slice(0, 5),
+    mode,
+    scannedCount: hnData.scannedCount,
+    duplicateCount: hnData.duplicateCount,
+  };
 }

--- a/src/report-builders.ts
+++ b/src/report-builders.ts
@@ -166,6 +166,10 @@ function escapeRadarTable(value: string): string {
   return value.replace(/\|/g, "\\|").replace(/\s+/g, " ").trim();
 }
 
+function escapeMarkdownLinkLabel(value: string): string {
+  return value.replace(/([\\[\]])/g, "\\$1");
+}
+
 export function buildRadarReportContent(
   data: RadarData,
   utcStr: string,
@@ -175,9 +179,10 @@ export function buildRadarReportContent(
 ): string {
   const mode = RADAR_REPORT.mode[data.mode][lang];
   const recommendations = data.top5
+    .slice(0, 5)
     .map(
       (item, index) =>
-        `### ${index + 1}. [${item.story.title}](${item.story.url}) — ${item.totalScore.toFixed(1)}\n\n` +
+        `### ${index + 1}. [${escapeMarkdownLinkLabel(item.story.title)}](${item.story.url}) — ${item.totalScore.toFixed(1)}\n\n` +
         `**${RADAR_REPORT.reason[lang]}:** ${item.reason[lang]}\n\n` +
         `[${RADAR_REPORT.discussion[lang]}](${item.story.hnUrl})`,
     )
@@ -186,7 +191,7 @@ export function buildRadarReportContent(
   const rows = data.items
     .map(
       (item, index) =>
-        `| ${index + 1} | [${escapeRadarTable(item.story.title)}](${item.story.url}) | ` +
+        `| ${index + 1} | [${escapeRadarTable(escapeMarkdownLinkLabel(item.story.title))}](${item.story.url}) | ` +
         `${item.totalScore.toFixed(1)} | ${item.story.points} | ${item.story.comments} | ` +
         `${escapeRadarTable(item.story.createdAt)} | ${escapeRadarTable(item.summary[lang])} |`,
     )

--- a/src/report-builders.ts
+++ b/src/report-builders.ts
@@ -163,11 +163,47 @@ export function buildOpenclawReportContent(
 }
 
 function escapeRadarTable(value: string): string {
-  return value.replace(/\|/g, "\\|").replace(/\s+/g, " ").trim();
+  return value.replace(/[\\|]/g, "\\$&").replace(/\s+/g, " ").trim();
 }
 
 function escapeMarkdownLinkLabel(value: string): string {
   return value.replace(/([\\[\]])/g, "\\$1");
+}
+
+function escapeRadarTableLinkLabel(value: string): string {
+  return value
+    .replace(/[\\|[\]]/g, "\\$&")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+function percentEncodeCharacter(value: string): string {
+  return Array.from(
+    new TextEncoder().encode(value),
+    (byte) => `%${byte.toString(16).toUpperCase().padStart(2, "0")}`,
+  ).join("");
+}
+
+function serializeMarkdownLinkDestination(value: string): string {
+  let encoded = "";
+  for (const character of value) {
+    const codePoint = character.codePointAt(0) ?? 0;
+    const isUnpairedSurrogate = codePoint >= 0xd800 && codePoint <= 0xdfff;
+    if (
+      character === "<" ||
+      character === ">" ||
+      character === "\\" ||
+      /\s/u.test(character) ||
+      codePoint < 0x20 ||
+      (codePoint >= 0x7f && codePoint <= 0x9f) ||
+      isUnpairedSurrogate
+    ) {
+      encoded += percentEncodeCharacter(character);
+    } else {
+      encoded += character;
+    }
+  }
+  return `<${encoded}>`;
 }
 
 export function buildRadarReportContent(
@@ -182,7 +218,7 @@ export function buildRadarReportContent(
     .slice(0, 5)
     .map(
       (item, index) =>
-        `### ${index + 1}. [${escapeMarkdownLinkLabel(item.story.title)}](${item.story.url}) — ${item.totalScore.toFixed(1)}\n\n` +
+        `### ${index + 1}. [${escapeMarkdownLinkLabel(item.story.title)}](${serializeMarkdownLinkDestination(item.story.url)}) — ${item.totalScore.toFixed(1)}\n\n` +
         `**${RADAR_REPORT.reason[lang]}:** ${item.reason[lang]}\n\n` +
         `[${RADAR_REPORT.discussion[lang]}](${item.story.hnUrl})`,
     )
@@ -191,7 +227,7 @@ export function buildRadarReportContent(
   const rows = data.items
     .map(
       (item, index) =>
-        `| ${index + 1} | [${escapeRadarTable(escapeMarkdownLinkLabel(item.story.title))}](${item.story.url}) | ` +
+        `| ${index + 1} | [${escapeRadarTableLinkLabel(item.story.title)}](${serializeMarkdownLinkDestination(item.story.url)}) | ` +
         `${item.totalScore.toFixed(1)} | ${item.story.points} | ${item.story.comments} | ` +
         `${escapeRadarTable(item.story.createdAt)} | ${escapeRadarTable(item.summary[lang])} |`,
     )

--- a/src/report-builders.ts
+++ b/src/report-builders.ts
@@ -4,7 +4,8 @@
 
 import type { RepoConfig, RepoFetch } from "./github.ts";
 import type { RepoDigest } from "./prompts.ts";
-import { type Lang, CLI_REPORT, OPENCLAW_REPORT, INFRA_REPORT } from "./i18n.ts";
+import type { RadarData } from "./radar.ts";
+import { type Lang, CLI_REPORT, OPENCLAW_REPORT, INFRA_REPORT, RADAR_REPORT } from "./i18n.ts";
 
 // ---------------------------------------------------------------------------
 // CLI Report
@@ -157,6 +158,55 @@ export function buildOpenclawReportContent(
     `\n\n---\n\n` +
     `## ${OPENCLAW_REPORT.peers[lang]}\n\n` +
     peerDetailSections +
+    footer
+  );
+}
+
+function escapeRadarTable(value: string): string {
+  return value.replace(/\|/g, "\\|").replace(/\s+/g, " ").trim();
+}
+
+export function buildRadarReportContent(
+  data: RadarData,
+  utcStr: string,
+  dateStr: string,
+  footer: string,
+  lang: Lang = "zh",
+): string {
+  const mode = RADAR_REPORT.mode[data.mode][lang];
+  const recommendations = data.top5
+    .map(
+      (item, index) =>
+        `### ${index + 1}. [${item.story.title}](${item.story.url}) — ${item.totalScore.toFixed(1)}\n\n` +
+        `**${RADAR_REPORT.reason[lang]}:** ${item.reason[lang]}\n\n` +
+        `[${RADAR_REPORT.discussion[lang]}](${item.story.hnUrl})`,
+    )
+    .join("\n\n");
+
+  const rows = data.items
+    .map(
+      (item, index) =>
+        `| ${index + 1} | [${escapeRadarTable(item.story.title)}](${item.story.url}) | ` +
+        `${item.totalScore.toFixed(1)} | ${item.story.points} | ${item.story.comments} | ` +
+        `${escapeRadarTable(item.story.createdAt)} | ${escapeRadarTable(item.summary[lang])} |`,
+    )
+    .join("\n");
+
+  const insufficient =
+    data.items.length < 5 ? `${RADAR_REPORT.insufficient(data.items.length, lang)}\n\n` : "";
+
+  return (
+    `# ${RADAR_REPORT.title[lang]} ${dateStr}\n\n` +
+    RADAR_REPORT.meta(data.scannedCount, data.items.length, data.duplicateCount, mode, utcStr, lang) +
+    `\n\n---\n\n## ${RADAR_REPORT.top5[lang]}\n\n` +
+    insufficient +
+    recommendations +
+    `\n\n---\n\n## ${RADAR_REPORT.allCandidates[lang]}\n\n` +
+    RADAR_REPORT.tableHeader[lang] +
+    "\n" +
+    RADAR_REPORT.tableAlign +
+    "\n" +
+    rows +
     footer
   );
 }

--- a/src/report-savers.ts
+++ b/src/report-savers.ts
@@ -8,6 +8,7 @@ import {
   WEB_REPORT,
   TRENDING_REPORT,
   HN_REPORT,
+  RADAR_REPORT,
   PH_REPORT,
   ARXIV_REPORT,
   HF_REPORT,
@@ -22,10 +23,12 @@ import {
   buildHfPrompt,
   buildCommunityPrompt,
 } from "./prompts-data.ts";
+import { buildRadarReportContent } from "./report-builders.ts";
 import { callLlm, saveFile, LLM_TOKENS_WEB, LLM_TOKENS_LISTING } from "./report.ts";
 import { createGitHubIssue } from "./github.ts";
 import { saveWebState, type WebFetchResult, type WebState } from "./web.ts";
 import type { HnData } from "./hn.ts";
+import type { RadarData } from "./radar.ts";
 import type { PhData } from "./ph.ts";
 import type { TrendingData } from "./trending.ts";
 import type { ArxivData } from "./arxiv.ts";
@@ -177,6 +180,35 @@ export async function saveHnReport(
     }
   } catch (err) {
     console.error(`  [hn/${lang}] Report generation failed: ${err}`);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Radar report
+// ---------------------------------------------------------------------------
+
+export async function saveRadarReport(
+  data: RadarData,
+  utcStr: string,
+  dateStr: string,
+  digestRepo: string,
+  footer: string,
+  lang: Lang = "zh",
+): Promise<void> {
+  if (data.items.length === 0) {
+    console.log(`  [radar/${lang}] No data available, skipping report.`);
+    return;
+  }
+  const fileName = lang === "en" ? "ai-radar-en.md" : "ai-radar.md";
+  const content = buildRadarReportContent(data, utcStr, dateStr, footer, lang);
+  console.log(`  Saved ${saveFile(content, dateStr, fileName)}`);
+  if (digestRepo) {
+    const url = await createGitHubIssue(
+      RADAR_REPORT.issueTitle(dateStr, lang),
+      content,
+      ISSUE_LABELS.radar[lang],
+    );
+    console.log(`  Created Radar issue (${lang}): ${url}`);
   }
 }
 


### PR DESCRIPTION
## What changed

- scan Hacker News Top Stories in rank order until up to 30 canonical URL/title-unique AI links are collected
- score every candidate deterministically, optionally enrich the ranking with one bilingual DeepSeek editorial request, and fall back safely when editorial output is unavailable or invalid
- generate Chinese and English Radar reports with all candidates plus a stable Top 5
- publish Radar through the manifest/RSS, Web UI, Telegram, Feishu, and GitHub label surfaces
- harden per-item HN failure isolation and Markdown link/table rendering
- document the DeepSeek and Windows PowerShell setup

## Why

The project needed a focused daily information-radar workflow that produces 30 deduplicated candidates and 5 actionable recommendations without replacing the existing digest architecture.

## Impact

Local runs write `ai-radar.md` and `ai-radar-en.md`. GitHub Issues remain opt-in through `DIGEST_REPO`. If the editorial model request fails, reports are still produced using deterministic scoring and are explicitly marked as fallback mode.

## Validation

- Prettier, ESLint, and TypeScript checks pass
- Vitest: 15 files, 251 tests passed
- faithful local Radar run produced 30 candidates, 5 recommendations, and two reports with 30 unique links
- secret-shape audit found no credentials in the branch diff or runtime reports

## Runtime note

The full legacy multi-source pipeline still encounters the current environment's concurrent network socket termination (`UND_ERR_SOCKET`). A production-module Radar-only run completed successfully; its single DeepSeek request was also terminated by the network, so the verified output used the built-in deterministic fallback rather than claiming model-generated scores.